### PR TITLE
feat: initialize macOS SwiftUI project

### DIFF
--- a/App/App.swift
+++ b/App/App.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// `MacosTokenizerApp` 是应用入口，负责启动并管理主窗口场景。
+@main
+struct MacosTokenizerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+
+/// `ContentView` 展示初始界面，仅显示欢迎文案。
+struct ContentView: View {
+    var body: some View {
+        Text("欢迎使用 macos-tokenizer")
+            .padding()
+    }
+}

--- a/macos-tokenizer.xcodeproj/project.pbxproj
+++ b/macos-tokenizer.xcodeproj/project.pbxproj
@@ -1,0 +1,291 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {
+};
+objectVersion = 56;
+objects = {
+
+/* Begin PBXBuildFile section */
+B4F5C1C02B3ED4F500A67135 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F5C1BF2B3ED4F500A67135 /* App.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+B4F5C1BF2B3ED4F500A67135 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
+B4F5C1C22B3ED4F500A67135 /* macos-tokenizer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "macos-tokenizer.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+B4F5C1BC2B3ED4F500A67135 /* Frameworks */ = {
+isa = PBXFrameworksBuildPhase;
+buildActionMask = 2147483647;
+files = (
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+B4F5C1B62B3ED4F500A67135 = {
+isa = PBXGroup;
+children = (
+B4F5C1BE2B3ED4F500A67135 /* App */,
+B4F5C1C12B3ED4F500A67135 /* Products */,
+);
+sourceTree = "<group>";
+};
+B4F5C1BE2B3ED4F500A67135 /* App */ = {
+isa = PBXGroup;
+children = (
+B4F5C1BF2B3ED4F500A67135 /* App.swift */,
+);
+path = App;
+sourceTree = "<group>";
+};
+B4F5C1C12B3ED4F500A67135 /* Products */ = {
+isa = PBXGroup;
+children = (
+B4F5C1C22B3ED4F500A67135 /* macos-tokenizer.app */,
+);
+name = Products;
+sourceTree = "<group>";
+};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+B4F5C1BD2B3ED4F500A67135 /* macos-tokenizer */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = B4F5C1CB2B3ED4F600A67135 /* Build configuration list for PBXNativeTarget "macos-tokenizer" */;
+buildPhases = (
+B4F5C1BB2B3ED4F500A67135 /* Sources */,
+B4F5C1BC2B3ED4F500A67135 /* Frameworks */,
+);
+buildRules = (
+);
+dependencies = (
+);
+name = "macos-tokenizer";
+productName = "macos-tokenizer";
+productReference = B4F5C1C22B3ED4F500A67135 /* macos-tokenizer.app */;
+productType = "com.apple.product-type.application";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+B4F5C1B72B3ED4F500A67135 /* Project object */ = {
+isa = PBXProject;
+attributes = {
+BuildIndependentTargetsInParallel = 1;
+LastSwiftUpdateCheck = 1500;
+LastUpgradeCheck = 1500;
+TargetAttributes = {
+B4F5C1BD2B3ED4F500A67135 = {
+CreatedOnToolsVersion = 15.0;
+};
+};
+};
+buildConfigurationList = B4F5C1BA2B3ED4F500A67135 /* Build configuration list for PBXProject "macos-tokenizer" */;
+compatibilityVersion = "Xcode 14.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+knownRegions = (
+en,
+);
+mainGroup = B4F5C1B62B3ED4F500A67135;
+productRefGroup = B4F5C1C12B3ED4F500A67135 /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+B4F5C1BD2B3ED4F500A67135 /* macos-tokenizer */,
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+B4F5C1BB2B3ED4F500A67135 /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+B4F5C1C02B3ED4F500A67135 /* App.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+B4F5C1C82B3ED4F600A67135 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+CODE_SIGN_STYLE = Automatic;
+COMBINE_HIDPI_IMAGES = YES;
+DEVELOPMENT_TEAM = "";
+ENABLE_HARDENED_RUNTIME = YES;
+GENERATE_INFOPLIST_FILE = YES;
+INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 macos-tokenizer";
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/../Frameworks",
+);
+MACOSX_DEPLOYMENT_TARGET = 13.0;
+MARKETING_VERSION = 1.0;
+PRODUCT_BUNDLE_IDENTIFIER = com.example.macosTokenizer;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+};
+name = Debug;
+};
+B4F5C1C92B3ED4F600A67135 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+CODE_SIGN_STYLE = Automatic;
+COMBINE_HIDPI_IMAGES = YES;
+DEVELOPMENT_TEAM = "";
+ENABLE_HARDENED_RUNTIME = YES;
+GENERATE_INFOPLIST_FILE = YES;
+INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 macos-tokenizer";
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/../Frameworks",
+);
+MACOSX_DEPLOYMENT_TARGET = 13.0;
+MARKETING_VERSION = 1.0;
+PRODUCT_BUNDLE_IDENTIFIER = com.example.macosTokenizer;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_EMIT_LOC_STRINGS = YES;
+SWIFT_VERSION = 5.0;
+};
+name = Release;
+};
+B4F5C1CC2B3ED4F600A67135 /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CLANG_WARN_UNREACHABLE_CODE = YES;
+CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = dwarf;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_TESTABILITY = YES;
+GCC_C_LANGUAGE_STANDARD = gnu17;
+GCC_DYNAMIC_NO_PIC = NO;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_OPTIMIZATION_LEVEL = 0;
+GCC_PREPROCESSOR_DEFINITIONS = (
+"DEBUG=1",
+"$(inherited)",
+);
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+MACOSX_DEPLOYMENT_TARGET = 13.0;
+MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+ONLY_ACTIVE_ARCH = YES;
+SDKROOT = macosx;
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+};
+name = Debug;
+};
+B4F5C1CD2B3ED4F600A67135 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CLANG_WARN_UNREACHABLE_CODE = YES;
+CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = dwarf;
+ENABLE_NS_ASSERTIONS = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+GCC_C_LANGUAGE_STANDARD = gnu17;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+MACOSX_DEPLOYMENT_TARGET = 13.0;
+MTL_ENABLE_DEBUG_INFO = NO;
+SDKROOT = macosx;
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_OPTIMIZATION_LEVEL = "-O";
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+B4F5C1BA2B3ED4F500A67135 /* Build configuration list for PBXProject "macos-tokenizer" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+B4F5C1CC2B3ED4F600A67135 /* Debug */,
+B4F5C1CD2B3ED4F600A67135 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+B4F5C1CB2B3ED4F600A67135 /* Build configuration list for PBXNativeTarget "macos-tokenizer" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+B4F5C1C82B3ED4F600A67135 /* Debug */,
+B4F5C1C92B3ED4F600A67135 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+/* End XCConfigurationList section */
+};
+rootObject = B4F5C1B72B3ED4F500A67135 /* Project object */;
+}

--- a/macos-tokenizer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/macos-tokenizer.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:macos-tokenizer.xcodeproj">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
## Summary
- add the initial SwiftUI app entry point with a placeholder welcome view
- create the Xcode project configured for macOS 13.0 and auto-generated Info.plist

## Testing
- not run (requires Xcode environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0993c27948323ba20549f6006b59f