### PR TITLE
feat: add MVVM placeholders and tokenizer engine protocol

### DIFF
--- a/Core/Tokenization/TokenizerEngine.swift
+++ b/Core/Tokenization/TokenizerEngine.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// 定义分词引擎的基本能力协议，供视图模型调用。
+public protocol TokenizerEngine {
+    /// 根据传入的原始文本执行分词。
+    /// - Parameter text: 待分词的原始文本内容。
+    /// - Returns: 分词后的字符串数组，保持原始顺序。
+    func tokenize(_ text: String) -> [String]
+}

--- a/Features/TokenizerUI/TokenizerMainView.swift
+++ b/Features/TokenizerUI/TokenizerMainView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+/// 负责展示分词器 UI 的主界面。
+/// - Note: 当前仅作为占位，后续将绑定 `TokenizerViewModel` 显示实际数据。
+struct TokenizerMainView: View {
+    /// 占位视图模型实例，后续将通过依赖注入替换。
+    @StateObject private var viewModel = TokenizerViewModel()
+
+    var body: some View {
+        Text(viewModel.tokens.isEmpty ? "Tokenizer UI 占位" : "分词结果占位")
+            .padding()
+    }
+}
+
+#Preview {
+    TokenizerMainView()
+}

--- a/Features/TokenizerUI/TokenizerViewModel.swift
+++ b/Features/TokenizerUI/TokenizerViewModel.swift
@@ -1,0 +1,12 @@
+import Combine
+import Foundation
+
+/// 负责协调 UI 与分词引擎的视图模型。
+/// - Note: 当前仅包含占位属性，后续将引入实际的业务逻辑与状态。
+final class TokenizerViewModel: ObservableObject {
+    /// 占位输入文本，后续将与界面输入框绑定。
+    @Published var inputText: String = ""
+
+    /// 占位输出结果列表，后续将展示在界面上。
+    @Published var tokens: [String] = []
+}


### PR DESCRIPTION
## Summary
- add placeholder SwiftUI view and view model for the tokenizer UI feature module
- define a tokenizer engine protocol stub with Chinese documentation comments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b488a6c083239beb1ffe2170dc22