### PR TITLE
chore: 菜单与快捷键占位 (A-04)

### DIFF
--- a/App/App.swift
+++ b/App/App.swift
@@ -3,9 +3,42 @@ import SwiftUI
 /// `MacosTokenizerApp` 是应用入口，负责启动并管理主窗口场景。
 @main
 struct MacosTokenizerApp: App {
+    /// 菜单动作：记录打开文件指令触发。
+    private func handleOpenFileCommand() {
+        print("[菜单] 打开文件占位指令")
+    }
+
+    /// 菜单动作：记录导出结果指令触发。
+    private func handleExportCommand() {
+        print("[菜单] 导出结果占位指令")
+    }
+
+    /// 菜单动作：记录清空指令触发。
+    private func handleClearCommand() {
+        print("[菜单] 清空内容占位指令")
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+        }
+        .commands {
+            CommandMenu("文件操作") {
+                Button("打开文件") {
+                    handleOpenFileCommand()
+                }
+                .keyboardShortcut("o", modifiers: .command)
+
+                Button("导出结果") {
+                    handleExportCommand()
+                }
+                .keyboardShortcut("e", modifiers: [.command, .shift])
+
+                Button("清空") {
+                    handleClearCommand()
+                }
+                .keyboardShortcut("k", modifiers: .command)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add placeholder menu commands for file actions in the app entry point
- wire up keyboard shortcuts that log placeholder actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b55bb50c8323ac432c7c96d94249