### PR TITLE
feat: 串联 UI 与分词引擎 (B-01)

### DIFF
--- a/Core/Tokenization/TokenizerEngine.swift
+++ b/Core/Tokenization/TokenizerEngine.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NaturalLanguage
 
 /// 定义分词引擎的基本能力协议，供视图模型调用。
 public protocol TokenizerEngine {
@@ -6,4 +7,35 @@ public protocol TokenizerEngine {
     /// - Parameter text: 待分词的原始文本内容。
     /// - Returns: 分词后的字符串数组，保持原始顺序。
     func tokenize(_ text: String) -> [String]
+}
+
+/// 默认分词引擎实现，基于 `NaturalLanguage.NLTokenizer`。
+public struct DefaultTokenizerEngine: TokenizerEngine {
+    private let unit: NLTokenUnit
+
+    /// 创建默认的分词引擎实例。
+    /// - Parameter unit: 分词粒度，默认按单词分割。
+    public init(unit: NLTokenUnit = .word) {
+        self.unit = unit
+    }
+
+    public func tokenize(_ text: String) -> [String] {
+        guard !text.isEmpty else {
+            return []
+        }
+
+        let tokenizer = NLTokenizer(unit: unit)
+        tokenizer.string = text
+
+        let fullRange = text.startIndex..<text.endIndex
+        let tokens = tokenizer.tokens(for: fullRange).map { range in
+            text[range]
+        }
+        .map { substring -> String in
+            substring.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        .filter { !$0.isEmpty }
+
+        return tokens
+    }
 }

--- a/Features/TokenizerUI/TokenizerMainView.swift
+++ b/Features/TokenizerUI/TokenizerMainView.swift
@@ -1,17 +1,92 @@
 import SwiftUI
 
 /// 负责展示分词器 UI 的主界面。
-/// - Note: 当前仅作为占位，后续将绑定 `TokenizerViewModel` 显示实际数据。
 struct TokenizerMainView: View {
-    /// 占位视图模型实例，后续将通过依赖注入替换。
-    @StateObject private var viewModel = TokenizerViewModel()
+    @StateObject private var viewModel: TokenizerViewModel
+
+    init(viewModel: TokenizerViewModel = TokenizerViewModel()) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
 
     var body: some View {
-        Text(viewModel.tokens.isEmpty ? "Tokenizer UI 占位" : "分词结果占位")
-            .padding()
+        HStack(spacing: 0) {
+            inputSection
+            Divider()
+            resultSection
+        }
+        .frame(minWidth: 700, minHeight: 400)
+    }
+
+    private var inputSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("输入文本")
+                .font(.headline)
+            TextEditor(text: $viewModel.inputText)
+                .font(.body)
+                .padding(8)
+                .background(Color(NSColor.textBackgroundColor))
+                .cornerRadius(8)
+            Spacer()
+        }
+        .padding()
+        .frame(minWidth: 320)
+    }
+
+    private var resultSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+            tokenList
+        }
+        .padding()
+        .frame(minWidth: 320, maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("分词结果")
+                .font(.headline)
+            HStack(spacing: 16) {
+                Label("总词数：\(viewModel.totalTokenCount)", systemImage: "number")
+                Label("唯一词数：\(viewModel.uniqueTokenCount)", systemImage: "circle.grid.cross")
+            }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private var tokenList: some View {
+        Group {
+            if viewModel.tokens.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "text.magnifyingglass")
+                        .font(.system(size: 42))
+                        .foregroundStyle(.secondary)
+                    Text("暂无结果")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                    Text("请输入文本以查看分词结果")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(Array(viewModel.tokens.enumerated()), id: \.offset) { index, token in
+                    HStack(alignment: .top, spacing: 12) {
+                        Text("\(index + 1)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 32, alignment: .trailing)
+                        Text(token)
+                            .font(.body)
+                            .multilineTextAlignment(.leading)
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
     }
 }
 
 #Preview {
-    TokenizerMainView()
+    TokenizerMainView(viewModel: TokenizerViewModel(initialText: "Hello SwiftUI tokenizer!"))
 }

--- a/Features/TokenizerUI/TokenizerViewModel.swift
+++ b/Features/TokenizerUI/TokenizerViewModel.swift
@@ -2,11 +2,39 @@ import Combine
 import Foundation
 
 /// 负责协调 UI 与分词引擎的视图模型。
-/// - Note: 当前仅包含占位属性，后续将引入实际的业务逻辑与状态。
 final class TokenizerViewModel: ObservableObject {
-    /// 占位输入文本，后续将与界面输入框绑定。
-    @Published var inputText: String = ""
+    /// 用户输入文本，与界面左侧输入框双向绑定。
+    @Published var inputText: String {
+        didSet {
+            processInput()
+        }
+    }
 
-    /// 占位输出结果列表，后续将展示在界面上。
-    @Published var tokens: [String] = []
+    /// 当前分词结果列表，保持输入顺序。
+    @Published private(set) var tokens: [String] = []
+
+    /// 分词后的总词数。
+    @Published private(set) var totalTokenCount: Int = 0
+
+    /// 分词后的唯一词数。
+    @Published private(set) var uniqueTokenCount: Int = 0
+
+    private let engine: TokenizerEngine
+
+    /// 创建视图模型实例。
+    /// - Parameters:
+    ///   - initialText: 初始输入文本，默认空字符串。
+    ///   - engine: 分词引擎，默认使用 `DefaultTokenizerEngine`。
+    init(initialText: String = "", engine: TokenizerEngine = DefaultTokenizerEngine()) {
+        self.engine = engine
+        self.inputText = initialText
+        processInput()
+    }
+
+    private func processInput() {
+        let result = engine.tokenize(inputText)
+        tokens = result
+        totalTokenCount = result.count
+        uniqueTokenCount = Set(result).count
+    }
 }


### PR DESCRIPTION
## Summary
- bind the tokenizer SwiftUI view to a stateful view model for live token updates
- implement a NaturalLanguage-based default tokenization engine and expose token statistics

## Testing
- not run (requires Xcode)


------
https://chatgpt.com/codex/tasks/task_e_68e0bcb9bce88323b0321b33481f6c87