### PR TITLE
feat: 文件导入导出与多格式支持 (B-02)

### DIFF
--- a/App/App.swift
+++ b/App/App.swift
@@ -3,50 +3,34 @@ import SwiftUI
 /// `MacosTokenizerApp` 是应用入口，负责启动并管理主窗口场景。
 @main
 struct MacosTokenizerApp: App {
-    /// 菜单动作：记录打开文件指令触发。
-    private func handleOpenFileCommand() {
-        print("[菜单] 打开文件占位指令")
-    }
-
-    /// 菜单动作：记录导出结果指令触发。
-    private func handleExportCommand() {
-        print("[菜单] 导出结果占位指令")
-    }
-
-    /// 菜单动作：记录清空指令触发。
-    private func handleClearCommand() {
-        print("[菜单] 清空内容占位指令")
-    }
+    @StateObject private var viewModel = TokenizerViewModel()
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            TokenizerMainView(viewModel: viewModel)
         }
         .commands {
             CommandMenu("文件操作") {
                 Button("打开文件") {
-                    handleOpenFileCommand()
+                    viewModel.handleOpenFileCommand()
                 }
                 .keyboardShortcut("o", modifiers: .command)
 
-                Button("导出结果") {
-                    handleExportCommand()
+                Button("导出 CSV") {
+                    viewModel.handleExportCSV()
                 }
                 .keyboardShortcut("e", modifiers: [.command, .shift])
 
+                Button("导出 JSON") {
+                    viewModel.handleExportJSON()
+                }
+                .keyboardShortcut("j", modifiers: [.command, .shift])
+
                 Button("清空") {
-                    handleClearCommand()
+                    viewModel.handleClear()
                 }
                 .keyboardShortcut("k", modifiers: .command)
             }
         }
-    }
-}
-
-/// `ContentView` 展示初始界面，仅显示欢迎文案。
-struct ContentView: View {
-    var body: some View {
-        Text("欢迎使用 macos-tokenizer")
-            .padding()
     }
 }

--- a/Core/Export/TokenExportService.swift
+++ b/Core/Export/TokenExportService.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// 导出分词结果可能遇到的错误，用于给用户展示友好提示。
+public enum TokenExportError: LocalizedError {
+    case writeFailed(underlying: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .writeFailed(let underlying):
+            return "导出失败：\(underlying.localizedDescription)"
+        }
+    }
+}
+
+/// 支持的导出格式枚举。
+public enum TokenExportFormat {
+    case csv
+    case json
+}
+
+/// 提供 CSV 与 JSON 导出的服务类。
+public final class TokenExportService {
+    public init() {}
+
+    /// 将 tokens 与词频写出到指定地址。
+    /// - Parameters:
+    ///   - tokens: 已分词的字符串数组。
+    ///   - url: 用户选择的导出文件地址。
+    ///   - format: 导出格式（CSV/JSON）。
+    public func export(tokens: [String], to url: URL, format: TokenExportFormat) throws {
+        let frequencies = buildFrequencyMap(from: tokens)
+        let data: Data
+
+        switch format {
+        case .csv:
+            data = buildCSVData(tokens: tokens, frequencies: frequencies)
+        case .json:
+            data = try buildJSONData(tokens: tokens, frequencies: frequencies)
+        }
+
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch {
+            throw TokenExportError.writeFailed(underlying: error)
+        }
+    }
+
+    private func buildFrequencyMap(from tokens: [String]) -> [String: Int] {
+        var map: [String: Int] = [:]
+        for token in tokens {
+            map[token, default: 0] += 1
+        }
+        return map
+    }
+
+    private func buildCSVData(tokens: [String], frequencies: [String: Int]) -> Data {
+        var rows: [String] = ["token,freq"]
+        var visited: Set<String> = []
+        for token in tokens where !visited.contains(token) {
+            visited.insert(token)
+            let escapedToken = csvEscaped(token)
+            let freq = frequencies[token, default: 0]
+            rows.append("\(escapedToken),\(freq)")
+        }
+        let csvString = rows.joined(separator: "\n")
+        return Data(csvString.utf8)
+    }
+
+    private func csvEscaped(_ value: String) -> String {
+        var escaped = value.replacingOccurrences(of: "\"", with: "\"\"")
+        if escaped.contains(",") || escaped.contains("\n") || escaped.contains("\r") || escaped.contains("\"") {
+            escaped = "\"\(escaped)\""
+        }
+        return escaped
+    }
+
+    private func buildJSONData(tokens: [String], frequencies: [String: Int]) throws -> Data {
+        let jsonObject: [String: Any] = [
+            "tokens": tokens,
+            "frequencies": frequencies
+        ]
+        do {
+            return try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted])
+        } catch {
+            throw TokenExportError.writeFailed(underlying: error)
+        }
+    }
+}

--- a/Core/FileImporter/FileImporter.swift
+++ b/Core/FileImporter/FileImporter.swift
@@ -1,0 +1,115 @@
+import Foundation
+import CoreXLSX
+
+/// 文件导入过程中可能出现的错误类型，需反馈给 UI 进行提示。
+public enum FileImportError: LocalizedError {
+    case unsupportedType
+    case readFailed(underlying: Error)
+    case parseFailed(underlying: Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedType:
+            return "暂不支持该文件格式，请选择 TXT 或 XLSX 文件。"
+        case .readFailed(let underlying):
+            return "文件读取失败：\(underlying.localizedDescription)"
+        case .parseFailed(let underlying):
+            return "文件解析失败：\(underlying.localizedDescription)"
+        }
+    }
+}
+
+/// 统一的文件导入协议，便于扩展更多格式。
+public protocol FileImporting {
+    /// 判断当前导入器是否可以处理指定 URL。
+    /// - Parameter url: 待检查的文件地址。
+    func canHandle(_ url: URL) -> Bool
+
+    /// 读取并解析文件内容。
+    /// - Parameter url: 待导入的文件地址。
+    /// - Returns: 解析出的纯文本内容。
+    func importContents(from url: URL) throws -> String
+}
+
+/// 将多个具体导入器组合的总服务，负责自动选择并导入。
+public final class FileImportService {
+    private let importers: [FileImporting]
+
+    /// 创建文件导入服务。
+    /// - Parameter importers: 支持的导入器列表，默认包含 TXT 与 XLSX。
+    public init(importers: [FileImporting] = [TextFileImporter(), ExcelFileImporter()]) {
+        self.importers = importers
+    }
+
+    /// 根据文件类型自动选择导入器并返回文本内容。
+    /// - Parameter url: 用户选择或拖入的文件地址。
+    /// - Throws: `FileImportError` 及底层错误。
+    /// - Returns: 导入得到的纯文本。
+    public func importFile(at url: URL) throws -> String {
+        guard let importer = importers.first(where: { $0.canHandle(url) }) else {
+            throw FileImportError.unsupportedType
+        }
+        return try importer.importContents(from: url)
+    }
+}
+
+/// 负责读取 UTF-8 文本文件的导入器。
+public struct TextFileImporter: FileImporting {
+    public init() {}
+
+    public func canHandle(_ url: URL) -> Bool {
+        url.pathExtension.lowercased() == "txt"
+    }
+
+    public func importContents(from url: URL) throws -> String {
+        do {
+            return try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            throw FileImportError.readFailed(underlying: error)
+        }
+    }
+}
+
+/// 负责解析 XLSX 文件并转换为纯文本的导入器。
+public struct ExcelFileImporter: FileImporting {
+    public init() {}
+
+    public func canHandle(_ url: URL) -> Bool {
+        url.pathExtension.lowercased() == "xlsx"
+    }
+
+    public func importContents(from url: URL) throws -> String {
+        guard let file = XLSXFile(filepath: url.path) else {
+            throw FileImportError.parseFailed(underlying: CocoaError(.fileReadCorruptFile))
+        }
+
+        do {
+            let sharedStrings = try file.parseSharedStrings()
+            var lines: [String] = []
+
+            for workbook in try file.parseWorkbooks() {
+                for (_, path) in try file.parseWorksheetPaths(workbook: workbook) {
+                    let worksheet = try file.parseWorksheet(at: path)
+                    let rows = worksheet.data?.rows ?? []
+                    for row in rows {
+                        let values = row.cells.compactMap { cell -> String? in
+                            if let stringValue = cell.stringValue(sharedStrings) {
+                                return stringValue
+                            }
+                            return cell.value
+                        }
+                        let trimmed = values.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                        if trimmed.allSatisfy({ $0.isEmpty }) {
+                            continue
+                        }
+                        lines.append(trimmed.joined(separator: "\t"))
+                    }
+                }
+            }
+
+            return lines.joined(separator: "\n")
+        } catch {
+            throw FileImportError.parseFailed(underlying: error)
+        }
+    }
+}

--- a/Features/TokenizerUI/TokenizerMainView.swift
+++ b/Features/TokenizerUI/TokenizerMainView.swift
@@ -1,8 +1,10 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// 负责展示分词器 UI 的主界面。
 struct TokenizerMainView: View {
     @StateObject private var viewModel: TokenizerViewModel
+    @State private var isDropTarget: Bool = false
 
     init(viewModel: TokenizerViewModel = TokenizerViewModel()) {
         _viewModel = StateObject(wrappedValue: viewModel)
@@ -15,6 +17,9 @@ struct TokenizerMainView: View {
             resultSection
         }
         .frame(minWidth: 700, minHeight: 400)
+        .alert(item: $viewModel.activeAlert) { alert in
+            Alert(title: Text("提示"), message: Text(alert.message), dismissButton: .default(Text("好的")))
+        }
     }
 
     private var inputSection: some View {
@@ -24,8 +29,11 @@ struct TokenizerMainView: View {
             TextEditor(text: $viewModel.inputText)
                 .font(.body)
                 .padding(8)
-                .background(Color(NSColor.textBackgroundColor))
+                .background(isDropTarget ? Color.accentColor.opacity(0.2) : Color(NSColor.textBackgroundColor))
                 .cornerRadius(8)
+                .onDrop(of: [UTType.fileURL], isTargeted: $isDropTarget) { providers in
+                    viewModel.handleDrop(providers: providers)
+                }
             Spacer()
         }
         .padding()
@@ -79,6 +87,12 @@ struct TokenizerMainView: View {
                         Text(token)
                             .font(.body)
                             .multilineTextAlignment(.leading)
+                        Spacer()
+                        if let frequency = viewModel.tokenFrequencies[token] {
+                            Text("频次：\(frequency)")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
                 .listStyle(.plain)

--- a/Features/TokenizerUI/TokenizerViewModel.swift
+++ b/Features/TokenizerUI/TokenizerViewModel.swift
@@ -1,7 +1,16 @@
+import AppKit
 import Combine
 import Foundation
+import UniformTypeIdentifiers
+
+/// 用于展示提示弹窗的数据模型。
+struct TokenizerAlert: Identifiable {
+    let id = UUID()
+    let message: String
+}
 
 /// 负责协调 UI 与分词引擎的视图模型。
+@MainActor
 final class TokenizerViewModel: ObservableObject {
     /// 用户输入文本，与界面左侧输入框双向绑定。
     @Published var inputText: String {
@@ -19,14 +28,26 @@ final class TokenizerViewModel: ObservableObject {
     /// 分词后的唯一词数。
     @Published private(set) var uniqueTokenCount: Int = 0
 
+    /// token 对应的词频映射。
+    @Published private(set) var tokenFrequencies: [String: Int] = [:]
+
+    /// 当前需要展示的提示信息。
+    @Published var activeAlert: TokenizerAlert?
+
     private let engine: TokenizerEngine
+    private let fileImportService: FileImportService
+    private let exportService: TokenExportService
 
     /// 创建视图模型实例。
     /// - Parameters:
     ///   - initialText: 初始输入文本，默认空字符串。
     ///   - engine: 分词引擎，默认使用 `DefaultTokenizerEngine`。
-    init(initialText: String = "", engine: TokenizerEngine = DefaultTokenizerEngine()) {
+    ///   - fileImportService: 文件导入服务。
+    ///   - exportService: 导出服务。
+    init(initialText: String = "", engine: TokenizerEngine = DefaultTokenizerEngine(), fileImportService: FileImportService = FileImportService(), exportService: TokenExportService = TokenExportService()) {
         self.engine = engine
+        self.fileImportService = fileImportService
+        self.exportService = exportService
         self.inputText = initialText
         processInput()
     }
@@ -36,5 +57,153 @@ final class TokenizerViewModel: ObservableObject {
         tokens = result
         totalTokenCount = result.count
         uniqueTokenCount = Set(result).count
+        tokenFrequencies = buildFrequencyMap(from: result)
+    }
+
+    private func buildFrequencyMap(from tokens: [String]) -> [String: Int] {
+        var map: [String: Int] = [:]
+        for token in tokens {
+            map[token, default: 0] += 1
+        }
+        return map
+    }
+
+    /// 菜单动作：展示打开文件面板并导入内容。
+    public func handleOpenFileCommand() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.allowedFileTypes = ["txt", "xlsx"]
+        panel.allowsMultipleSelection = false
+        panel.begin { [weak panel] response in
+            guard response == .OK, let url = panel?.url else { return }
+            self.importFile(from: url)
+        }
+    }
+
+    /// 菜单动作：导出为 CSV。
+    public func handleExportCSV() {
+        presentSavePanel(for: .csv)
+    }
+
+    /// 菜单动作：导出为 JSON。
+    public func handleExportJSON() {
+        presentSavePanel(for: .json)
+    }
+
+    /// 菜单动作：清空输入内容。
+    public func handleClear() {
+        inputText = ""
+        activeAlert = TokenizerAlert(message: "已清空输入内容。")
+    }
+
+    /// 处理拖拽进入窗口的文件。
+    /// - Parameter providers: 拖拽提供的项目列表。
+    /// - Returns: 是否接管本次拖拽。
+    public func handleDrop(providers: [NSItemProvider]) -> Bool {
+        guard let provider = providers.first(where: { $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) }) else {
+            presentError(message: "暂不支持该文件类型，请拖入 TXT 或 XLSX。", error: nil)
+            return false
+        }
+
+        provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, error in
+            if let error {
+                DispatchQueue.main.async {
+                    self.presentError(message: "读取拖拽文件失败。", error: error)
+                }
+                return
+            }
+
+            if let data = item as? Data, let url = URL(dataRepresentation: data, relativeTo: nil) {
+                DispatchQueue.main.async {
+                    self.importFile(from: url)
+                }
+            } else if let url = item as? URL {
+                DispatchQueue.main.async {
+                    self.importFile(from: url)
+                }
+            } else {
+                DispatchQueue.main.async {
+                    self.presentError(message: "无法识别拖入的文件地址。", error: nil)
+                }
+            }
+        }
+
+        return true
+    }
+
+    private func presentSavePanel(for format: TokenExportFormat) {
+        guard !tokens.isEmpty else {
+            activeAlert = TokenizerAlert(message: "暂无可导出的分词结果。")
+            return
+        }
+
+        let panel = NSSavePanel()
+        panel.canCreateDirectories = true
+        switch format {
+        case .csv:
+            panel.allowedFileTypes = ["csv"]
+            panel.nameFieldStringValue = defaultFileName(withExtension: "csv")
+        case .json:
+            panel.allowedFileTypes = ["json"]
+            panel.nameFieldStringValue = defaultFileName(withExtension: "json")
+        }
+
+        panel.begin { [weak panel] response in
+            guard response == .OK, let url = panel?.url else { return }
+            self.export(to: url, format: format)
+        }
+    }
+
+    private func defaultFileName(withExtension ext: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return "tokenizer-result-\(formatter.string(from: Date())).\(ext)"
+    }
+
+    private func importFile(from url: URL) {
+        print("[导入] 准备读取文件: \(url.path)")
+        let service = fileImportService
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let content = try service.importFile(at: url)
+                DispatchQueue.main.async {
+                    self.inputText = content
+                    self.activeAlert = TokenizerAlert(message: "已导入 \(url.lastPathComponent)")
+                    print("[导入] 成功: \(url.lastPathComponent)")
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.presentError(message: (error as? LocalizedError)?.errorDescription ?? "导入失败。", error: error)
+                }
+            }
+        }
+    }
+
+    private func export(to url: URL, format: TokenExportFormat) {
+        let tokens = self.tokens
+        let service = exportService
+        print("[导出] 写入文件: \(url.path)")
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try service.export(tokens: tokens, to: url, format: format)
+                DispatchQueue.main.async {
+                    self.activeAlert = TokenizerAlert(message: "已导出至 \(url.lastPathComponent)")
+                    print("[导出] 成功: \(url.lastPathComponent)")
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.presentError(message: (error as? LocalizedError)?.errorDescription ?? "导出失败。", error: error)
+                }
+            }
+        }
+    }
+
+    private func presentError(message: String, error: Error?) {
+        if let error {
+            print("[错误] \(message) -> \(error)")
+        } else {
+            print("[错误] \(message)")
+        }
+        activeAlert = TokenizerAlert(message: message)
     }
 }


### PR DESCRIPTION
## Summary
- add CoreXLSX-backed importer service to parse TXT and XLSX files into plain text
- add CSV/JSON export service with token frequency aggregation and UI alerts for success or failure
- wire menu commands, drag-and-drop, and save panels through the tokenizer view model and SwiftUI view

## Testing
- not run (not supported in container)

------
https://chatgpt.com/codex/tasks/task_e_68e0c247b70c832395f1779c8c1ad110