### PR TITLE
fix: 增强导入导出异常处理 (B-04)

### DIFF
--- a/App/App.swift
+++ b/App/App.swift
@@ -20,11 +20,13 @@ struct MacosTokenizerApp: App {
                     viewModel.handleExportCSV()
                 }
                 .keyboardShortcut("e", modifiers: [.command, .shift])
+                .disabled(viewModel.isBusy)
 
                 Button("导出 JSON") {
                     viewModel.handleExportJSON()
                 }
                 .keyboardShortcut("j", modifiers: [.command, .shift])
+                .disabled(viewModel.isBusy)
 
                 Button("清空") {
                     viewModel.handleClear()

--- a/Core/Export/TokenExportService.swift
+++ b/Core/Export/TokenExportService.swift
@@ -7,6 +7,20 @@ public enum TokenExportError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .writeFailed(let underlying):
+            if let cocoaError = underlying as? CocoaError {
+                switch cocoaError.code {
+                case .fileWriteNoPermission:
+                    return "导出失败：目标位置没有写入权限。"
+                case .fileWriteVolumeReadOnly:
+                    return "导出失败：目标磁盘为只读。"
+                case .fileWriteOutOfSpace:
+                    return "导出失败：磁盘空间不足。"
+                case .fileWriteFileExists:
+                    return "导出失败：目标文件正在被占用。"
+                default:
+                    break
+                }
+            }
             return "导出失败：\(underlying.localizedDescription)"
         }
     }

--- a/Features/TokenizerUI/TokenizerMainView.swift
+++ b/Features/TokenizerUI/TokenizerMainView.swift
@@ -75,6 +75,23 @@ struct TokenizerMainView: View {
                 .font(.footnote)
                 .foregroundStyle(.secondary)
 
+            if viewModel.isBusy {
+                Label(viewModel.busyStatusMessage ?? "处理中…", systemImage: "hourglass")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color(NSColor.windowBackgroundColor))
+                    .cornerRadius(8)
+
+                Button("取消") {}
+                    .font(.footnote)
+                    .disabled(true)
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("取消当前任务（开发中）")
+            }
+
             if !viewModel.searchQuery.isEmpty {
                 Button {
                     viewModel.updateSearch(query: "")


### PR DESCRIPTION
## Summary
- enrich file importer error coverage for unsupported encodings, empty workbooks, and invalid cells
- improve export error descriptions for common macOS failures
- surface busy/error state in the tokenizer UI to show processing status and disable export commands

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0c7764b748323aee07afffcb5eeb4