### PR TITLE
feat: introduce AppShell navigation shell

### DIFF
--- a/App/App.swift
+++ b/App/App.swift
@@ -7,7 +7,7 @@ struct MacosTokenizerApp: App {
 
     var body: some Scene {
         WindowGroup {
-            TokenizerMainView(viewModel: viewModel)
+            AppShellView(tokenizerViewModel: viewModel)
         }
         .commands {
             CommandMenu("文件操作") {

--- a/Features/Components/AppShell/AppShellView.swift
+++ b/Features/Components/AppShell/AppShellView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+/// `AppShellView` 构建应用壳层，提供统一的侧边栏导航与顶部工具栏。
+struct AppShellView: View {
+    @ObservedObject var tokenizerViewModel: TokenizerViewModel
+    @State private var selection: AppRoute? = .analyze
+
+    var body: some View {
+        NavigationSplitView {
+            sidebar
+        } detail: {
+            detailContainer
+        }
+        .navigationSplitViewStyle(.balanced)
+    }
+
+    private var sidebar: some View {
+        List(selection: $selection) {
+            ForEach(AppRoute.allCases) { route in
+                SidebarItem(route: route, isSelected: selection == route)
+                    .tag(route)
+                    .listRowInsets(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
+                    .listRowBackground(Color.clear)
+            }
+        }
+        .listStyle(.sidebar)
+        .navigationTitle("macOS Tokenizer")
+    }
+
+    private var detailContainer: some View {
+        let activeRoute = selection ?? .analyze
+        return VStack(spacing: 0) {
+            topBar(for: activeRoute)
+            Divider()
+            detailContent(for: activeRoute)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color(nsColor: .underPageBackgroundColor))
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+    }
+
+    private func topBar(for route: AppRoute) -> some View {
+        HStack(spacing: 16) {
+            Label(route.title, systemImage: route.systemImageName)
+                .font(.title2)
+                .fontWeight(.semibold)
+            Spacer()
+            HStack(spacing: 12) {
+                // 右侧预留操作区域，后续放入导入/导出等按钮。
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+
+    @ViewBuilder
+    private func detailContent(for route: AppRoute) -> some View {
+        switch route {
+        case .dashboard:
+            DashboardPlaceholderView()
+        case .analyze:
+            AnalyzeWorkspaceView(viewModel: tokenizerViewModel)
+        case .batch:
+            BatchPlaceholderView()
+        case .dictionaries:
+            DictionariesPlaceholderView()
+        case .logs:
+            LogsPlaceholderView()
+        case .settings:
+            SettingsPlaceholderView()
+        }
+    }
+}
+
+private struct SidebarItem: View {
+    let route: AppRoute
+    let isSelected: Bool
+    @State private var isHovered: Bool = false
+
+    var body: some View {
+        Label(route.title, systemImage: route.systemImageName)
+            .font(.body)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .background(background)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .foregroundStyle(isSelected ? Color.accentColor : Color.primary)
+            .onHover { hovering in
+                isHovered = hovering
+            }
+    }
+
+    private var background: some View {
+        Group {
+            if isSelected {
+                Color.accentColor.opacity(0.15)
+            } else if isHovered {
+                Color.secondary.opacity(0.1)
+            } else {
+                Color.clear
+            }
+        }
+    }
+}
+
+#Preview {
+    AppShellView(tokenizerViewModel: TokenizerViewModel())
+}

--- a/Features/Shell/AppRoute.swift
+++ b/Features/Shell/AppRoute.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// `AppRoute` 枚举描述应用的导航目的地，用于侧边栏与内容区的同步切换。
+enum AppRoute: String, CaseIterable, Identifiable {
+    case dashboard
+    case analyze
+    case batch
+    case dictionaries
+    case logs
+    case settings
+
+    var id: String { rawValue }
+
+    /// 返回在侧边栏中展示的标题。
+    var title: String {
+        switch self {
+        case .dashboard: return "Dashboard"
+        case .analyze: return "Analyze"
+        case .batch: return "Batch"
+        case .dictionaries: return "Dictionaries"
+        case .logs: return "Logs"
+        case .settings: return "Settings"
+        }
+    }
+
+    /// 对应的 SF Symbols 图标名称。
+    var systemImageName: String {
+        switch self {
+        case .dashboard: return "square.grid.2x2"
+        case .analyze: return "text.magnifyingglass"
+        case .batch: return "tray.full"
+        case .dictionaries: return "book"
+        case .logs: return "doc.text"
+        case .settings: return "gearshape"
+        }
+    }
+}

--- a/Features/Shell/PlaceholderViews.swift
+++ b/Features/Shell/PlaceholderViews.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// `AnalyzeWorkspaceView` 嵌入已有的分词主界面，保证单文分析功能保持可用。
+struct AnalyzeWorkspaceView: View {
+    @ObservedObject var viewModel: TokenizerViewModel
+
+    var body: some View {
+        TokenizerMainView(viewModel: viewModel)
+    }
+}
+
+/// `DashboardPlaceholderView` 展示仪表盘占位界面。
+struct DashboardPlaceholderView: View {
+    var body: some View {
+        ComingSoonContainer(title: "Dashboard", message: "Overview widgets are under construction.")
+    }
+}
+
+/// `BatchPlaceholderView` 展示批量处理模块的占位界面。
+struct BatchPlaceholderView: View {
+    var body: some View {
+        ComingSoonContainer(title: "Batch", message: "Batch processing tools will arrive soon.")
+    }
+}
+
+/// `DictionariesPlaceholderView` 展示词典管理的占位界面。
+struct DictionariesPlaceholderView: View {
+    var body: some View {
+        ComingSoonContainer(title: "Dictionaries", message: "Manage custom dictionaries in a future update.")
+    }
+}
+
+/// `LogsPlaceholderView` 展示日志列表的占位界面。
+struct LogsPlaceholderView: View {
+    var body: some View {
+        ComingSoonContainer(title: "Logs", message: "Usage and error logs are being prepared.")
+    }
+}
+
+/// `SettingsPlaceholderView` 展示设置面板的占位界面。
+struct SettingsPlaceholderView: View {
+    var body: some View {
+        ComingSoonContainer(title: "Settings", message: "Configuration options will be added later.")
+    }
+}
+
+private struct ComingSoonContainer: View {
+    let title: String
+    let message: String
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.largeTitle)
+                .fontWeight(.semibold)
+            Text("Coming soon")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            Text(message)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 320)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable AppShellView with sidebar navigation, top bar, and hover/selection states
- define the AppRoute enum plus placeholder detail views for pending modules
- update the app entry point to present the new shell while reusing the existing tokenizer workspace for Analyze

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e0cb3f25e083239a4112c21b9cdad4