### PR TITLE
feat: 通用卡片与统计组件 (B+-02)

### DIFF
--- a/Core/Infra/DesignSystem.swift
+++ b/Core/Infra/DesignSystem.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+/// 设计系统基础 Token，集中管理颜色、间距与圆角。
+public enum DesignSystem {
+    public enum Colors {
+        public enum Light {
+            public static let background = Color(hex: 0xF6F7FB)
+            public static let card = Color(hex: 0xFFFFFF)
+            public static let textPrimary = Color(hex: 0x0F172A)
+            public static let textSecondary = Color(hex: 0x475569)
+            public static let accent = Color(hex: 0x4F46E5)
+            public static let divider = Color(hex: 0xE2E8F0)
+            public static let success = Color(hex: 0x10B981)
+            public static let warning = Color(hex: 0xF59E0B)
+            public static let error = Color(hex: 0xEF4444)
+            public static let info = Color(hex: 0x3B82F6)
+        }
+
+        public enum Dark {
+            public static let background = Color(hex: 0x0F172A)
+            public static let card = Color(hex: 0x1E293B)
+            public static let textPrimary = Color.white
+            public static let textSecondary = Color(hex: 0xCBD5F5)
+            public static let accent = Color(hex: 0x6366F1)
+            public static let divider = Color(hex: 0x334155)
+            public static let success = Color(hex: 0x10B981)
+            public static let warning = Color(hex: 0xF59E0B)
+            public static let error = Color(hex: 0xEF4444)
+            public static let info = Color(hex: 0x3B82F6)
+        }
+
+        public struct BadgeColorSet {
+            public let foreground: Color
+            public let background: Color
+
+            public init(foreground: Color, background: Color) {
+                self.foreground = foreground
+                self.background = background
+            }
+        }
+
+        public enum Badge {
+            public static let success = BadgeColorSet(
+                foreground: Light.success,
+                background: Color(hex: 0x10B981, alpha: 0.14)
+            )
+            public static let warning = BadgeColorSet(
+                foreground: Light.warning,
+                background: Color(hex: 0xF59E0B, alpha: 0.18)
+            )
+            public static let error = BadgeColorSet(
+                foreground: Light.error,
+                background: Color(hex: 0xEF4444, alpha: 0.16)
+            )
+            public static let info = BadgeColorSet(
+                foreground: Light.info,
+                background: Color(hex: 0x3B82F6, alpha: 0.14)
+            )
+        }
+
+        public static let background = Light.background
+        public static let card = Light.card
+        public static let textPrimary = Light.textPrimary
+        public static let textSecondary = Light.textSecondary
+        public static let accent = Light.accent
+        public static let divider = Light.divider
+    }
+
+    public enum CornerRadius {
+        public static let card: CGFloat = 18
+        public static let badge: CGFloat = 10
+        public static let button: CGFloat = 12
+    }
+
+    public enum Spacing {
+        public static let xs: CGFloat = 8
+        public static let sm: CGFloat = 12
+        public static let md: CGFloat = 16
+        public static let lg: CGFloat = 24
+    }
+
+    public enum Shadows {
+        public static let card = ShadowStyle(
+            color: Color(hex: 0x0F172A, alpha: 0.08),
+            radius: 12,
+            x: 0,
+            y: 2
+        )
+        public static let cardHover = ShadowStyle(
+            color: Color(hex: 0x0F172A, alpha: 0.12),
+            radius: 18,
+            x: 0,
+            y: 8
+        )
+    }
+
+    public enum Typography {
+        public static let title = Font.system(size: 18, weight: .semibold)
+        public static let subtitle = Font.system(size: 14, weight: .regular)
+        public static let body = Font.system(size: 15, weight: .regular)
+        public static let caption = Font.system(size: 13, weight: .regular)
+        public static let value = Font.system(size: 32, weight: .semibold, design: .monospaced)
+        public static let label = Font.system(size: 13, weight: .semibold)
+    }
+
+    public struct ShadowStyle {
+        public let color: Color
+        public let radius: CGFloat
+        public let x: CGFloat
+        public let y: CGFloat
+
+        public init(color: Color, radius: CGFloat, x: CGFloat, y: CGFloat) {
+            self.color = color
+            self.radius = radius
+            self.x = x
+            self.y = y
+        }
+    }
+}
+
+private extension Color {
+    init(hex: UInt32, alpha: Double = 1.0) {
+        let red = Double((hex & 0xFF0000) >> 16) / 255.0
+        let green = Double((hex & 0x00FF00) >> 8) / 255.0
+        let blue = Double(hex & 0x0000FF) / 255.0
+        self = Color(.sRGB, red: red, green: green, blue: blue, opacity: alpha)
+    }
+}

--- a/Features/Components/Badge.swift
+++ b/Features/Components/Badge.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// 徽标样式枚举，区分不同状态颜色。
+public enum BadgeStyle {
+    case success
+    case warning
+    case error
+    case info
+}
+
+/// 状态徽标组件，支持 Success/Warning/Error/Info 四种样式。
+public struct Badge: View {
+    private let style: BadgeStyle
+    private let text: String
+
+    /// 初始化状态徽标，传入样式与展示文本。
+    public init(style: BadgeStyle, text: String) {
+        self.style = style
+        self.text = text
+    }
+
+    public var body: some View {
+        Text(text)
+            .font(DesignSystem.Typography.caption)
+            .padding(.vertical, 4)
+            .padding(.horizontal, DesignSystem.Spacing.sm)
+            .foregroundStyle(colorSet.foreground)
+            .background(
+                RoundedRectangle(cornerRadius: DesignSystem.CornerRadius.badge, style: .continuous)
+                    .fill(colorSet.background)
+            )
+            .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var colorSet: DesignSystem.Colors.BadgeColorSet {
+        switch style {
+        case .success:
+            return DesignSystem.Colors.Badge.success
+        case .warning:
+            return DesignSystem.Colors.Badge.warning
+        case .error:
+            return DesignSystem.Colors.Badge.error
+        case .info:
+            return DesignSystem.Colors.Badge.info
+        }
+    }
+
+    private var accessibilityLabel: Text {
+        Text("状态：\(text)")
+    }
+}

--- a/Features/Components/Card.swift
+++ b/Features/Components/Card.swift
@@ -1,0 +1,199 @@
+import SwiftUI
+
+/// 通用卡片容器，支持标题、副标题与右上角动作插槽。
+public struct Card<TrailingActions: View, Content: View>: View {
+    private let title: String?
+    private let subtitle: String?
+    private let includesTrailingActions: Bool
+    private let trailingActions: () -> TrailingActions
+    private let content: () -> Content
+
+    @State private var isHovering = false
+
+    fileprivate init(
+        title: String?,
+        subtitle: String?,
+        includesTrailingActions: Bool,
+        @ViewBuilder trailingActions: @escaping () -> TrailingActions,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.includesTrailingActions = includesTrailingActions
+        self.trailingActions = trailingActions
+        self.content = content
+    }
+
+    /// 初始化卡片并提供右上角自定义动作插槽。
+    public init(
+        title: String? = nil,
+        subtitle: String? = nil,
+        @ViewBuilder trailingActions: @escaping () -> TrailingActions,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.init(
+            title: title,
+            subtitle: subtitle,
+            includesTrailingActions: true,
+            trailingActions: trailingActions,
+            content: content
+        )
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            if shouldShowHeader {
+                header
+            }
+
+            content()
+        }
+        .padding(DesignSystem.Spacing.lg)
+        .background(DesignSystem.Colors.card)
+        .cornerRadius(DesignSystem.CornerRadius.card)
+        .shadow(
+            color: currentShadow.color,
+            radius: currentShadow.radius,
+            x: currentShadow.x,
+            y: currentShadow.y
+        )
+        .animation(.easeInOut(duration: 0.2), value: isHovering)
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isHovering = hovering
+            }
+        }
+    }
+
+    private var shouldShowHeader: Bool {
+        (title?.isEmpty == false) || (subtitle?.isEmpty == false) || includesTrailingActions
+    }
+
+    private var currentShadow: DesignSystem.ShadowStyle {
+        isHovering ? DesignSystem.Shadows.cardHover : DesignSystem.Shadows.card
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
+            VStack(alignment: .leading, spacing: 4) {
+                if let title {
+                    Text(title)
+                        .font(DesignSystem.Typography.title)
+                        .foregroundStyle(DesignSystem.Colors.textPrimary)
+                }
+
+                if let subtitle {
+                    Text(subtitle)
+                        .font(DesignSystem.Typography.subtitle)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                }
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.sm)
+
+            if includesTrailingActions {
+                trailingActions()
+            }
+        }
+    }
+}
+
+public extension Card where TrailingActions == EmptyView {
+    /// 便捷初始化，适用于无右上角动作的卡片。
+    /// 初始化卡片，省略动作插槽时使用该便捷方法。
+    init(
+        title: String? = nil,
+        subtitle: String? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.init(
+            title: title,
+            subtitle: subtitle,
+            includesTrailingActions: false,
+            trailingActions: { EmptyView() },
+            content: content
+        )
+    }
+}
+
+/// 键值列表卡片，用于展示文件名、大小等信息。
+public struct KeyValueCard: View {
+    private let title: String?
+    private let subtitle: String?
+    private let items: [(key: String, value: String)]
+    private let maxVisible: Int?
+    private let rowHeight: CGFloat = 36
+
+    /// 传入键值数组及可选显示上限，生成信息列表卡片。
+    public init(
+        title: String? = nil,
+        subtitle: String? = nil,
+        items: [(key: String, value: String)],
+        maxVisible: Int? = nil
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.items = items
+        self.maxVisible = maxVisible
+    }
+
+    public var body: some View {
+        Card(title: title, subtitle: subtitle) {
+            contentView
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        if shouldScroll {
+            ScrollView {
+                keyValueList
+                    .padding(.vertical, 2)
+            }
+            .frame(maxHeight: maxContentHeight)
+        } else {
+            keyValueList
+        }
+    }
+
+    private var keyValueList: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                if index > 0 {
+                    Divider()
+                        .background(DesignSystem.Colors.divider)
+                }
+                KeyValueRow(item: item)
+            }
+        }
+    }
+
+    private var shouldScroll: Bool {
+        guard let maxVisible else { return false }
+        return items.count > maxVisible
+    }
+
+    private var maxContentHeight: CGFloat {
+        guard let maxVisible else { return .infinity }
+        return CGFloat(maxVisible) * rowHeight
+    }
+}
+
+private struct KeyValueRow: View {
+    let item: (key: String, value: String)
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: DesignSystem.Spacing.sm) {
+            Text(item.key)
+                .font(DesignSystem.Typography.label)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            Spacer(minLength: DesignSystem.Spacing.sm)
+            Text(item.value)
+                .font(DesignSystem.Typography.body)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+                .multilineTextAlignment(.trailing)
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/Features/Components/StatCard.swift
+++ b/Features/Components/StatCard.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// SF Symbol 名称别名，便于区分参数语义。
+public typealias SFSymbol = String
+
+/// 关键指标卡片，突出数字指标并支持可选图标与脚注。
+public struct StatCard: View {
+    private let title: String
+    private let value: String
+    private let icon: SFSymbol?
+    private let footnote: String?
+
+    /// 初始化关键指标卡片，传入标题、主数值及可选图标与脚注。
+    public init(
+        title: String,
+        value: String,
+        icon: SFSymbol? = nil,
+        footnote: String? = nil
+    ) {
+        self.title = title
+        self.value = value
+        self.icon = icon
+        self.footnote = footnote
+    }
+
+    public var body: some View {
+        Group {
+            if let icon {
+                Card(title: title, subtitle: nil, trailingActions: {
+                    Image(systemName: icon)
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(DesignSystem.Colors.accent)
+                        .accessibilityHidden(true)
+                }) {
+                    content
+                }
+            } else {
+                Card(title: title, subtitle: nil) {
+                    content
+                }
+            }
+        }
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text(value)
+                .font(DesignSystem.Typography.value)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+            if let footnote {
+                Text(footnote)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared design system with color, typography, spacing, and shadow tokens
- implement reusable Card and KeyValueCard containers using the design system
- introduce StatCard and Badge components styled by the new tokens

## Testing
- not run (requires macOS/Xcode)


------
https://chatgpt.com/codex/tasks/task_e_68e0cdb9570083238c475237b5df2e9d