### PR TITLE
feat: 首页 Dashboard 网格与占位内容 (B+-03)

### DIFF
--- a/Features/Components/AppShell/AppShellView.swift
+++ b/Features/Components/AppShell/AppShellView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// `AppShellView` 构建应用壳层，提供统一的侧边栏导航与顶部工具栏。
 struct AppShellView: View {
     @ObservedObject var tokenizerViewModel: TokenizerViewModel
+    @StateObject private var dashboardViewModel = DashboardViewModel()
     @State private var selection: AppRoute? = .analyze
 
     var body: some View {
@@ -57,7 +58,7 @@ struct AppShellView: View {
     private func detailContent(for route: AppRoute) -> some View {
         switch route {
         case .dashboard:
-            DashboardPlaceholderView()
+            DashboardView(viewModel: dashboardViewModel)
         case .analyze:
             AnalyzeWorkspaceView(viewModel: tokenizerViewModel)
         case .batch:

--- a/Features/Dashboard/DashboardView.swift
+++ b/Features/Dashboard/DashboardView.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+/// `DashboardView` 构建首页仪表盘界面，展示占位统计与快捷入口。 
+struct DashboardView: View {
+    @ObservedObject var viewModel: DashboardViewModel
+
+    private let cardMinWidth: CGFloat = 320
+    private let columnSpacing = DesignSystem.Spacing.lg
+    private let rankColumnWidth: CGFloat = 56
+    private let fileSizeColumnWidth: CGFloat = 80
+    private let fileDateColumnWidth: CGFloat = 112
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                ForEach(viewModel.metrics) { metric in
+                    StatCard(
+                        title: metric.title,
+                        value: metric.value,
+                        icon: metric.icon,
+                        footnote: metric.footnote
+                    )
+                }
+
+                wordFrequencyCard
+                recentFilesCard
+                quickStartCard
+            }
+            .padding(.horizontal, DesignSystem.Spacing.lg)
+            .padding(.vertical, DesignSystem.Spacing.lg)
+        }
+        .background(DesignSystem.Colors.background)
+    }
+
+    private var columns: [GridItem] {
+        [
+            GridItem(
+                .adaptive(minimum: cardMinWidth),
+                spacing: columnSpacing,
+                alignment: .top
+            )
+        ]
+    }
+
+    private var wordFrequencyCard: some View {
+        Card(title: "词频 Top 10", subtitle: "最近分析文本的高频词") {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                ForEach(Array(viewModel.wordFrequencies.enumerated()), id: \.element.id) { index, item in
+                    if index > 0 {
+                        Divider()
+                            .background(DesignSystem.Colors.divider)
+                    }
+
+                    HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+                        Text(String(format: "#%02d", item.rank))
+                            .font(DesignSystem.Typography.label)
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                            .frame(width: rankColumnWidth, alignment: .leading)
+
+                        VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                            Text(item.word)
+                                .font(DesignSystem.Typography.body)
+                                .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+                            if let badgeText = item.badgeText {
+                                Badge(style: item.badgeStyle, text: badgeText)
+                            }
+                        }
+
+                        Spacer(minLength: DesignSystem.Spacing.sm)
+
+                        VStack(alignment: .trailing, spacing: DesignSystem.Spacing.xs) {
+                            Text("\(item.count) 次")
+                                .font(DesignSystem.Typography.body)
+                                .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+                            Text(item.trend)
+                                .font(DesignSystem.Typography.caption)
+                                .foregroundStyle(trendColor(for: item))
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+    }
+
+    private var recentFilesCard: some View {
+        Card(title: "最近文件", subtitle: "继续处理你最近的文档") {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    Text("文件名")
+                        .font(DesignSystem.Typography.label)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Text("大小")
+                        .font(DesignSystem.Typography.label)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .frame(width: fileSizeColumnWidth, alignment: .trailing)
+                    Text("更新时间")
+                        .font(DesignSystem.Typography.label)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .frame(width: fileDateColumnWidth, alignment: .trailing)
+                }
+
+                ForEach(Array(viewModel.recentFiles.enumerated()), id: \.element.id) { index, file in
+                    if index > 0 {
+                        Divider()
+                            .background(DesignSystem.Colors.divider)
+                    }
+
+                    HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
+                        Text(file.name)
+                            .font(DesignSystem.Typography.body)
+                            .foregroundStyle(DesignSystem.Colors.textPrimary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .lineLimit(1)
+
+                        Text(file.size)
+                            .font(DesignSystem.Typography.body)
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                            .frame(width: fileSizeColumnWidth, alignment: .trailing)
+
+                        Text(file.updatedAt)
+                            .font(DesignSystem.Typography.body)
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                            .frame(width: fileDateColumnWidth, alignment: .trailing)
+                    }
+                }
+            }
+        }
+    }
+
+    private var quickStartCard: some View {
+        Card(title: "快速开始", subtitle: "选择一种方式导入文本") {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    ForEach(viewModel.quickActions) { action in
+                        Button {
+                            viewModel.handleQuickAction(action)
+                        } label: {
+                            Label(action.title, systemImage: action.symbol)
+                                .font(DesignSystem.Typography.body)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, DesignSystem.Spacing.sm)
+                                .padding(.horizontal, DesignSystem.Spacing.md)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(DesignSystem.Colors.accent)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Divider()
+                    .background(DesignSystem.Colors.divider)
+
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                    Text("或者直接拖拽文本/文件到窗口，立即开始分词。")
+                        .font(DesignSystem.Typography.body)
+                        .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    Text("支持 TXT、Markdown、CSV 等常见格式。")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                }
+            }
+        }
+    }
+
+    private func trendColor(for item: DashboardViewModel.WordFrequencyItem) -> Color {
+        item.trend.contains("↓") ? DesignSystem.Colors.textSecondary : DesignSystem.Colors.accent
+    }
+}
+
+#Preview {
+    DashboardView(viewModel: DashboardViewModel())
+        .frame(width: 1200, height: 900)
+}

--- a/Features/Dashboard/DashboardViewModel.swift
+++ b/Features/Dashboard/DashboardViewModel.swift
@@ -1,0 +1,80 @@
+import Foundation
+import SwiftUI
+
+/// `DashboardViewModel` 提供首页仪表盘的占位数据，后续可替换为真实统计。 
+final class DashboardViewModel: ObservableObject {
+    struct Metric: Identifiable {
+        let id = UUID()
+        let title: String
+        let value: String
+        let icon: SFSymbol?
+        let footnote: String?
+    }
+
+    struct WordFrequencyItem: Identifiable {
+        let id = UUID()
+        let rank: Int
+        let word: String
+        let count: Int
+        let badgeText: String?
+        let badgeStyle: BadgeStyle
+        let trend: String
+    }
+
+    struct RecentFile: Identifiable {
+        let id = UUID()
+        let name: String
+        let size: String
+        let updatedAt: String
+    }
+
+    struct QuickAction: Identifiable {
+        let id = UUID()
+        let title: String
+        let symbol: SFSymbol
+    }
+
+    @Published var metrics: [Metric]
+    @Published var wordFrequencies: [WordFrequencyItem]
+    @Published var recentFiles: [RecentFile]
+    let quickActions: [QuickAction]
+
+    init() {
+        metrics = [
+            Metric(title: "总词数", value: "128,450", icon: "character.cursor.ibeam", footnote: "较昨日 +12%"),
+            Metric(title: "唯一词数", value: "8,920", icon: "textformat.abc", footnote: "覆盖 4 种语言"),
+            Metric(title: "上次处理耗时", value: "182 ms", icon: "timer", footnote: "文本长度 24,500 字"),
+        ]
+
+        wordFrequencies = [
+            WordFrequencyItem(rank: 1, word: "数据", count: 482, badgeText: "名词", badgeStyle: .info, trend: "↑ 18%"),
+            WordFrequencyItem(rank: 2, word: "分析", count: 430, badgeText: "动词", badgeStyle: .success, trend: "↑ 9%"),
+            WordFrequencyItem(rank: 3, word: "模型", count: 398, badgeText: "名词", badgeStyle: .info, trend: "↑ 4%"),
+            WordFrequencyItem(rank: 4, word: "训练", count: 364, badgeText: "动词", badgeStyle: .success, trend: "↓ 3%"),
+            WordFrequencyItem(rank: 5, word: "优化", count: 342, badgeText: "动词", badgeStyle: .success, trend: "↑ 6%"),
+            WordFrequencyItem(rank: 6, word: "准确率", count: 321, badgeText: "指标", badgeStyle: .warning, trend: "↑ 12%"),
+            WordFrequencyItem(rank: 7, word: "语料", count: 310, badgeText: "名词", badgeStyle: .info, trend: "↑ 5%"),
+            WordFrequencyItem(rank: 8, word: "推理", count: 288, badgeText: "动词", badgeStyle: .success, trend: "↓ 1%"),
+            WordFrequencyItem(rank: 9, word: "部署", count: 264, badgeText: "动词", badgeStyle: .success, trend: "↑ 2%"),
+            WordFrequencyItem(rank: 10, word: "评估", count: 251, badgeText: "动词", badgeStyle: .success, trend: "↑ 7%"),
+        ]
+
+        recentFiles = [
+            RecentFile(name: "产品需求-0423.md", size: "512 KB", updatedAt: "今天 10:24"),
+            RecentFile(name: "季度汇报-v2.key", size: "1.8 MB", updatedAt: "昨天 19:12"),
+            RecentFile(name: "客服对话-样例.csv", size: "742 KB", updatedAt: "3 天前"),
+            RecentFile(name: "语料-机器学习.txt", size: "2.4 MB", updatedAt: "上周"),
+            RecentFile(name: "会议记录-产品评审.docx", size: "968 KB", updatedAt: "上周"),
+        ]
+
+        quickActions = [
+            QuickAction(title: "粘贴文本", symbol: "doc.on.clipboard"),
+            QuickAction(title: "打开文件", symbol: "folder.badge.plus"),
+        ]
+    }
+
+    /// 快速开始按钮的点击占位逻辑，后续接入真实操作。 
+    func handleQuickAction(_ action: QuickAction) {
+        print("[Dashboard] Quick action triggered: \(action.title)")
+    }
+}


### PR DESCRIPTION
## Summary
- add the new Dashboard view with adaptive card grid and placeholder content
- provide a DashboardViewModel that surfaces mock stats, word frequency, files, and quick actions
- integrate the Dashboard page into AppShell routing to replace the placeholder screen

## Testing
- ⚠️ `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d678bd4c8323b99215f225e3c1f0