### PR TITLE
feat: Sparkline 趋势组件 (B+-04)

### DIFF
--- a/Features/Components/SparklineView.swift
+++ b/Features/Components/SparklineView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+import Charts
+
+/// 小型趋势图组件，接收数值序列并绘制简洁火花线。外部传入数据源与数值 KeyPath。
+public struct SparklineView<DataPoint: Identifiable>: View {
+    private let data: [DataPoint]
+    private let valueKeyPath: KeyPath<DataPoint, Double>
+    private let lineWidth: CGFloat
+    private let cornerRadius: CGFloat
+    private let inset: CGFloat
+
+    @State private var isHovering = false
+
+    public init(
+        data: [DataPoint],
+        value: KeyPath<DataPoint, Double>,
+        lineWidth: CGFloat = 1.5,
+        cornerRadius: CGFloat = 8,
+        inset: CGFloat = 8
+    ) {
+        self.data = data
+        valueKeyPath = value
+        self.lineWidth = lineWidth
+        self.cornerRadius = cornerRadius
+        self.inset = inset
+    }
+
+    public var body: some View {
+        Chart {
+            ForEach(Array(data.enumerated()), id: \.element.id) { index, element in
+                LineMark(
+                    x: .value("序号", index),
+                    y: .value("数值", element[keyPath: valueKeyPath])
+                )
+                .interpolationMethod(.catmullRom)
+                .lineStyle(
+                    StrokeStyle(
+                        lineWidth: lineWidth,
+                        lineCap: .round,
+                        lineJoin: .round
+                    )
+                )
+                .foregroundStyle(lineColor)
+            }
+        }
+        .chartLegend(.hidden)
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .chartPlotStyle { plotArea in
+            plotArea
+                .background(plotBackground)
+                .cornerRadius(cornerRadius)
+        }
+        .padding(inset)
+        .frame(minHeight: 48)
+        .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isHovering = hovering
+            }
+        }
+    }
+
+    private var lineColor: Color {
+        isHovering ? DesignSystem.Colors.accent : DesignSystem.Colors.accent.opacity(0.92)
+    }
+
+    private var plotBackground: some View {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .fill(DesignSystem.Colors.accent.opacity(isHovering ? 0.14 : 0.08))
+    }
+}

--- a/Features/Dashboard/DashboardView.swift
+++ b/Features/Dashboard/DashboardView.swift
@@ -9,6 +9,25 @@ struct DashboardView: View {
     private let rankColumnWidth: CGFloat = 56
     private let fileSizeColumnWidth: CGFloat = 80
     private let fileDateColumnWidth: CGFloat = 112
+    private let processingTrendSamples: [ProcessingTrendPoint] = [
+        .init(index: 0, value: 168),
+        .init(index: 1, value: 154),
+        .init(index: 2, value: 149),
+        .init(index: 3, value: 132),
+        .init(index: 4, value: 141),
+        .init(index: 5, value: 135),
+        .init(index: 6, value: 128),
+        .init(index: 7, value: 121),
+        .init(index: 8, value: 118),
+        .init(index: 9, value: 112)
+    ]
+
+    private struct ProcessingTrendPoint: Identifiable {
+        let index: Int
+        let value: Double
+
+        var id: Int { index }
+    }
 
     var body: some View {
         ScrollView {
@@ -22,6 +41,7 @@ struct DashboardView: View {
                     )
                 }
 
+                processingTrendCard
                 wordFrequencyCard
                 recentFilesCard
                 quickStartCard
@@ -40,6 +60,33 @@ struct DashboardView: View {
                 alignment: .top
             )
         ]
+    }
+
+    private var processingTrendCard: some View {
+        Card(title: "处理耗时趋势", subtitle: "最近 10 次任务 (ms)") {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                SparklineView(
+                    data: processingTrendSamples,
+                    value: \ProcessingTrendPoint.value,
+                    lineWidth: 2,
+                    cornerRadius: 12,
+                    inset: DesignSystem.Spacing.sm
+                )
+                .frame(height: 96)
+
+                HStack(alignment: .firstTextBaseline) {
+                    Text("最近一次")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    Spacer()
+                    if let latest = processingTrendSamples.last?.value {
+                        Text("\(Int(latest)) ms")
+                            .font(DesignSystem.Typography.body)
+                            .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    }
+                }
+            }
+        }
     }
 
     private var wordFrequencyCard: some View {


### PR DESCRIPTION
## Summary
- add a reusable SparklineView built on Apple Charts for trend visualization
- embed the sparkline in DashboardView with sample processing time data for preview

## Testing
- not run (requires macOS)


------
https://chatgpt.com/codex/tasks/task_e_68e0d85f589483238c44ad18ce2134c5