### PR TITLE
refactor: 分析页卡片化布局 (B+-05)

### DIFF
--- a/Features/TokenizerUI/TokenizerMainView.swift
+++ b/Features/TokenizerUI/TokenizerMainView.swift
@@ -11,50 +11,267 @@ struct TokenizerMainView: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            inputSection
-            Divider()
-            resultSection
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(spacing: DesignSystem.Spacing.lg) {
+                    toolbarCard
+
+                    HStack(alignment: .top, spacing: DesignSystem.Spacing.lg) {
+                        inputColumn
+                            .frame(width: leftColumnWidth(for: proxy.size))
+
+                        resultsColumn
+                            .frame(width: rightColumnWidth(for: proxy.size))
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .padding(.horizontal, DesignSystem.Spacing.lg)
+                .padding(.vertical, DesignSystem.Spacing.lg)
+                .frame(minHeight: proxy.size.height, alignment: .top)
+            }
+            .frame(width: proxy.size.width)
+            .background(DesignSystem.Colors.background)
         }
-        .frame(minWidth: 700, minHeight: 400)
+        .frame(minWidth: 900, minHeight: 600)
         .alert(item: $viewModel.activeAlert) { alert in
             Alert(title: Text("提示"), message: Text(alert.message), dismissButton: .default(Text("好的")))
         }
     }
 
-    private var inputSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("输入文本")
-                .font(.headline)
+    private var toolbarCard: some View {
+        Card(title: "分析工具", subtitle: "导入、导出或切换分词引擎") {
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                Button {
+                    viewModel.handleOpenFileCommand()
+                } label: {
+                    Label("导入文本", systemImage: "tray.and.arrow.down")
+                        .font(DesignSystem.Typography.body)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(DesignSystem.Colors.accent)
+
+                Menu {
+                    Button("导出 CSV") {
+                        viewModel.handleExportCSV()
+                    }
+                    Button("导出 JSON") {
+                        viewModel.handleExportJSON()
+                    }
+                } label: {
+                    Label("导出结果", systemImage: "square.and.arrow.up")
+                        .font(DesignSystem.Typography.body)
+                }
+                .menuStyle(.borderedButton)
+
+                Button {
+                    viewModel.handleClear()
+                } label: {
+                    Label("清空输入", systemImage: "trash")
+                        .font(DesignSystem.Typography.body)
+                }
+                .buttonStyle(.bordered)
+                .tint(DesignSystem.Colors.textSecondary)
+
+                Spacer(minLength: DesignSystem.Spacing.md)
+
+                Menu {
+                    ForEach(viewModel.engineOptions) { option in
+                        Button(option.displayName) {
+                            viewModel.selectEngine(option)
+                        }
+                        .disabled(!option.isAvailable)
+                    }
+                } label: {
+                    Label(viewModel.selectedEngine.displayName, systemImage: "gearshape.2.fill")
+                        .font(DesignSystem.Typography.body)
+                }
+                .menuStyle(.borderedButton)
+            }
+        }
+    }
+
+    private var inputColumn: some View {
+        VStack(spacing: DesignSystem.Spacing.lg) {
+            Card(title: "输入文本", subtitle: "支持粘贴、拖拽或导入文件") {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                    inputEditor
+
+                    Divider()
+                        .background(DesignSystem.Colors.divider)
+
+                    settingsSection
+                }
+            }
+        }
+    }
+
+    private var inputEditor: some View {
+        ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(DesignSystem.Colors.background)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(isDropTarget ? DesignSystem.Colors.accent : DesignSystem.Colors.divider, lineWidth: isDropTarget ? 2 : 1)
+                )
+
             TextEditor(text: $viewModel.inputText)
-                .font(.body)
-                .padding(8)
-                .background(isDropTarget ? Color.accentColor.opacity(0.2) : Color(NSColor.textBackgroundColor))
-                .cornerRadius(8)
+                .font(DesignSystem.Typography.body)
+                .padding(DesignSystem.Spacing.sm)
+                .background(Color.clear)
+                .frame(minHeight: 320)
                 .onDrop(of: [UTType.fileURL], isTargeted: $isDropTarget) { providers in
                     viewModel.handleDrop(providers: providers)
                 }
-            Spacer()
+
+            if viewModel.inputText.isEmpty {
+                Text("粘贴文本、拖入 .txt/.xlsx，或按 ⌘O 打开文件开始分词。")
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .padding(.top, DesignSystem.Spacing.sm)
+                    .padding(.horizontal, DesignSystem.Spacing.sm)
+                    .allowsHitTesting(false)
+            }
         }
-        .padding()
-        .frame(minWidth: 320)
     }
 
-    private var resultSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            searchBar
-            header
-            tokenList
+    private var settingsSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("分析设置")
+                .font(DesignSystem.Typography.label)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                settingRow(title: "语言", value: "自动检测")
+                settingRow(title: "粒度", value: "按单词切分")
+                settingRow(title: "导入提示", value: "支持 TXT/XLSX 拖拽")
+            }
+
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                Text("实时状态")
+                    .font(DesignSystem.Typography.body)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                Badge(style: viewModel.isBusy ? .warning : .success, text: statusText)
+                Spacer()
+            }
         }
-        .padding()
-        .frame(minWidth: 320, maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var statusText: String {
+        if viewModel.isBusy {
+            return viewModel.busyStatusMessage ?? "处理中"
+        }
+        return "实时分词"
+    }
+
+    private var resultsColumn: some View {
+        ZStack {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+                resultCard
+                frequencyCard
+                statsGrid
+            }
+
+            if viewModel.isBusy {
+                Color.black.opacity(0.05)
+                    .ignoresSafeArea()
+
+                ProgressView(viewModel.busyStatusMessage ?? "处理中…")
+                    .progressViewStyle(.circular)
+                    .controlSize(.large)
+                    .padding(DesignSystem.Spacing.lg)
+                    .background(DesignSystem.Colors.card)
+                    .cornerRadius(DesignSystem.CornerRadius.card)
+                    .shadow(
+                        color: DesignSystem.Shadows.card.color,
+                        radius: DesignSystem.Shadows.card.radius,
+                        x: DesignSystem.Shadows.card.x,
+                        y: DesignSystem.Shadows.card.y
+                    )
+            }
+        }
+    }
+
+    private var resultCard: some View {
+        Card(title: "分词结果", subtitle: resultSubtitle) {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                searchBar
+
+                Divider()
+                    .background(DesignSystem.Colors.divider)
+
+                if viewModel.tokens.isEmpty {
+                    emptyState
+                } else {
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                            ForEach(Array(viewModel.tokens.enumerated()), id: \.offset) { index, token in
+                                tokenRow(index: index, token: token)
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+                    .frame(minHeight: 240)
+                }
+            }
+        }
+    }
+
+    private var resultSubtitle: String {
+        if viewModel.tokens.isEmpty {
+            return "等待输入以展示分词结果"
+        }
+        return "共 \(viewModel.totalTokenCount) 个词元"
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: DesignSystem.Spacing.md) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .font(.system(size: 48))
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            Text("还没有分词结果")
+                .font(DesignSystem.Typography.title)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            Text("粘贴文本、拖入文件或按 ⌘O 打开文档开始分析。")
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 240)
+    }
+
+    private func tokenRow(index: Int, token: String) -> some View {
+        let isMatched = viewModel.isTokenMatched(index: index)
+        return HStack(alignment: .top, spacing: DesignSystem.Spacing.sm) {
+            Text(String(format: "#%03d", index + 1))
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .frame(width: 56, alignment: .leading)
+
+            Text(token)
+                .font(DesignSystem.Typography.body)
+                .foregroundStyle(isMatched ? DesignSystem.Colors.accent : DesignSystem.Colors.textPrimary)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: DesignSystem.Spacing.sm)
+
+            if let frequency = viewModel.tokenFrequencies[token] {
+                Text("\(frequency) 次")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+        }
+        .padding(.vertical, DesignSystem.Spacing.xs)
+        .padding(.horizontal, DesignSystem.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(isMatched ? DesignSystem.Colors.accent.opacity(0.12) : DesignSystem.Colors.background)
+        )
     }
 
     private var searchBar: some View {
-        HStack(spacing: 12) {
-            HStack(spacing: 6) {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            HStack(spacing: DesignSystem.Spacing.xs) {
                 Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
                 TextField(
                     "搜索分词",
                     text: Binding(
@@ -63,101 +280,132 @@ struct TokenizerMainView: View {
                     )
                 )
                 .textFieldStyle(.plain)
+                .font(DesignSystem.Typography.body)
+
+                if !viewModel.searchQuery.isEmpty {
+                    Button {
+                        viewModel.updateSearch(query: "")
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("清除搜索")
+                }
             }
-            .padding(.vertical, 6)
-            .padding(.horizontal, 8)
-            .background(Color(NSColor.textBackgroundColor))
-            .cornerRadius(8)
-
-            Spacer()
-
-            Text("匹配 \(viewModel.matchCount) 项")
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-
-            if viewModel.isBusy {
-                Label(viewModel.busyStatusMessage ?? "处理中…", systemImage: "hourglass")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(Color(NSColor.windowBackgroundColor))
-                    .cornerRadius(8)
-
-                Button("取消") {}
-                    .font(.footnote)
-                    .disabled(true)
-                    .buttonStyle(.borderless)
-                    .foregroundStyle(.secondary)
-                    .accessibilityLabel("取消当前任务（开发中）")
-            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, DesignSystem.Spacing.sm)
+            .background(DesignSystem.Colors.background)
+            .cornerRadius(12)
 
             if !viewModel.searchQuery.isEmpty {
-                Button {
-                    viewModel.updateSearch(query: "")
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("清除搜索")
+                Badge(style: .info, text: "命中 \(viewModel.matchCount)")
             }
+
+            Spacer()
         }
     }
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("分词结果")
-                .font(.headline)
-            HStack(spacing: 16) {
-                Label("总词数：\(viewModel.totalTokenCount)", systemImage: "number")
-                Label("唯一词数：\(viewModel.uniqueTokenCount)", systemImage: "circle.grid.cross")
-            }
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
-        }
-    }
-
-    private var tokenList: some View {
-        Group {
-            if viewModel.tokens.isEmpty {
-                VStack(spacing: 12) {
-                    Image(systemName: "doc.text.magnifyingglass")
-                        .font(.system(size: 48))
-                        .foregroundStyle(.secondary)
-                    Text("还没有分词结果")
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
-                    Text("粘贴文本、拖入 .txt/.xlsx，或按 ⌘O 打开文件开始分词。")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+    private var frequencyCard: some View {
+        Card(title: "词频 Top 20", subtitle: "按照出现次数排序") {
+            if topTokenFrequencies.isEmpty {
+                Text("暂无词频统计，先输入文本开始分析。")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
             } else {
-                List(Array(viewModel.tokens.enumerated()), id: \.offset) { index, token in
-                    HStack(alignment: .top, spacing: 12) {
-                        Text("\(index + 1)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .frame(width: 32, alignment: .trailing)
-                        Text(token)
-                            .font(.body)
-                            .multilineTextAlignment(.leading)
-                            .padding(4)
-                            .background(viewModel.isTokenMatched(index: index) ? Color.accentColor.opacity(0.2) : Color.clear)
-                            .clipShape(RoundedRectangle(cornerRadius: 4))
-                        Spacer()
-                        if let frequency = viewModel.tokenFrequencies[token] {
-                            Text("频次：\(frequency)")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                    ForEach(Array(topTokenFrequencies.enumerated()), id: \.element.token) { index, item in
+                        if index > 0 {
+                            Divider()
+                                .background(DesignSystem.Colors.divider)
+                        }
+
+                        HStack(alignment: .center, spacing: DesignSystem.Spacing.sm) {
+                            Text(String(format: "#%02d", index + 1))
+                                .font(DesignSystem.Typography.label)
+                                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                                .frame(width: 52, alignment: .leading)
+
+                            Text(item.token)
+                                .font(DesignSystem.Typography.body)
+                                .foregroundStyle(DesignSystem.Colors.textPrimary)
+                                .lineLimit(2)
+
+                            Spacer()
+
+                            Text("\(item.count) 次")
+                                .font(DesignSystem.Typography.body)
+                                .foregroundStyle(DesignSystem.Colors.textSecondary)
                         }
                     }
                 }
-                .listStyle(.plain)
             }
         }
+    }
+
+    private var statsGrid: some View {
+        let columns = [
+            GridItem(.adaptive(minimum: 220), spacing: DesignSystem.Spacing.lg, alignment: .top)
+        ]
+
+        return LazyVGrid(columns: columns, alignment: .leading, spacing: DesignSystem.Spacing.lg) {
+            StatCard(
+                title: "总词数",
+                value: "\(viewModel.totalTokenCount)",
+                icon: "number",
+                footnote: "包含重复项"
+            )
+
+            StatCard(
+                title: "唯一词数",
+                value: "\(viewModel.uniqueTokenCount)",
+                icon: "circle.grid.cross",
+                footnote: "去重后统计"
+            )
+
+            StatCard(
+                title: "处理耗时",
+                value: formattedDuration,
+                icon: "timer",
+                footnote: "最近一次分词"
+            )
+        }
+    }
+
+    private var formattedDuration: String {
+        guard viewModel.processingDuration > 0 else { return "--" }
+        return String(format: "%.2f 秒", viewModel.processingDuration)
+    }
+
+    private var topTokenFrequencies: [(token: String, count: Int)] {
+        let sorted = viewModel.tokenFrequencies.sorted { lhs, rhs in
+            if lhs.value == rhs.value {
+                return lhs.key < rhs.key
+            }
+            return lhs.value > rhs.value
+        }
+        return Array(sorted.prefix(20))
+            .map { (token: $0.key, count: $0.value) }
+    }
+
+    private func settingRow(title: String, value: String) -> some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            Text(title)
+                .font(DesignSystem.Typography.body)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            Spacer()
+            Text(value)
+                .font(DesignSystem.Typography.body)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+        }
+    }
+
+    private func leftColumnWidth(for size: CGSize) -> CGFloat {
+        max(size.width * 0.32, 320)
+    }
+
+    private func rightColumnWidth(for size: CGSize) -> CGFloat {
+        max(size.width - leftColumnWidth(for: size) - DesignSystem.Spacing.lg, 480)
     }
 }
 


### PR DESCRIPTION
## Summary
- restructure the Analyze view into a card-based two-column layout that matches the dashboard styling and introduces toolbar controls for import/export/engine selection
- expose lightweight processing duration and engine menu state in the view model to feed the new UI elements

## Testing
- not run (macOS-only SwiftUI project; container lacks Xcode)


------
https://chatgpt.com/codex/tasks/task_e_68e0d8ce96a08323aa535064002475b9