### PR TITLE
Add project references and minimal tokenizer/export tests

### DIFF
--- a/Tests/ExportTests.swift
+++ b/Tests/ExportTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import macos_tokenizer
+
+final class ExportTests: XCTestCase {
+    private var exportService: TokenExportService!
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        exportService = TokenExportService()
+        temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: temporaryDirectory)
+        exportService = nil
+        temporaryDirectory = nil
+        try super.tearDownWithError()
+    }
+
+    func testCSVExportEscapesSpecialCharacters() throws {
+        let tokens = [
+            "hello",
+            "value,with,comma",
+            "value,with,comma",
+            "value\"quote"
+        ]
+        let destination = temporaryDirectory.appendingPathComponent("tokens").appendingPathExtension("csv")
+
+        try exportService.export(tokens: tokens, to: destination, format: .csv)
+
+        let csv = try String(contentsOf: destination, encoding: .utf8)
+        let rows = csv.split(separator: "\n").map(String.init)
+
+        XCTAssertEqual(rows.first, "token,freq")
+        XCTAssertEqual(rows.count, 4)
+        XCTAssertTrue(rows.contains("hello,1"))
+        XCTAssertTrue(rows.contains("\"value,with,comma\",2"))
+        XCTAssertTrue(rows.contains("\"value\"\"quote\",1"))
+    }
+
+    func testJSONExportContainsTokensAndFrequencies() throws {
+        let tokens = ["你", "好", "world", "123", "你"]
+        let destination = temporaryDirectory.appendingPathComponent("tokens").appendingPathExtension("json")
+
+        try exportService.export(tokens: tokens, to: destination, format: .json)
+
+        let data = try Data(contentsOf: destination)
+        let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
+
+        guard let dictionary = jsonObject as? [String: Any] else {
+            XCTFail("Root JSON object should be a dictionary")
+            return
+        }
+
+        guard let exportedTokens = dictionary["tokens"] as? [String] else {
+            XCTFail("Tokens array missing from JSON output")
+            return
+        }
+
+        XCTAssertEqual(exportedTokens, tokens)
+
+        guard let frequencyObject = dictionary["frequencies"] as? [String: Any] else {
+            XCTFail("Frequencies dictionary missing from JSON output")
+            return
+        }
+
+        let frequencies = frequencyObject.reduce(into: [String: Int]()) { partialResult, element in
+            if let number = element.value as? NSNumber {
+                partialResult[element.key] = number.intValue
+            }
+        }
+
+        XCTAssertEqual(frequencies.count, Set(tokens).count)
+        XCTAssertEqual(frequencies["你"], 2)
+        XCTAssertEqual(frequencies["好"], 1)
+        XCTAssertEqual(frequencies["world"], 1)
+        XCTAssertEqual(frequencies["123"], 1)
+    }
+}

--- a/Tests/TokenizationTests.swift
+++ b/Tests/TokenizationTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import macos_tokenizer
+
+final class TokenizationTests: XCTestCase {
+    private var engine: TokenizerEngine!
+
+    override func setUp() {
+        super.setUp()
+        engine = DefaultTokenizerEngine()
+    }
+
+    override func tearDown() {
+        engine = nil
+        super.tearDown()
+    }
+
+    func testEmptyInputProducesNoTokens() {
+        let tokens = engine.tokenize("")
+        XCTAssertTrue(tokens.isEmpty, "Empty input should yield no tokens")
+        XCTAssertEqual(Set(tokens).count, 0)
+    }
+
+    func testMixedLanguageTokenization() {
+        let input = "你好，world 123！"
+        let tokens = engine.tokenize(input)
+
+        XCTAssertTrue(tokens.contains("你好"), "Chinese phrase should be preserved as a token")
+        XCTAssertTrue(tokens.contains("world"), "English words should be tokenized correctly")
+        XCTAssertTrue(tokens.contains("123"), "Numbers should appear in the token list")
+
+        let punctuation = CharacterSet.punctuationCharacters
+        XCTAssertFalse(tokens.contains { token in
+            token.rangeOfCharacter(from: punctuation) != nil
+        }, "Tokens should not include punctuation marks")
+
+        XCTAssertTrue((3...4).contains(tokens.count), "Mixed input should produce between three and four tokens depending on locale segmentation")
+        XCTAssertEqual(tokens.count, Set(tokens).count, "Unique token count should match the number of produced tokens")
+    }
+
+    func testLongEnglishParagraphTokenCounts() {
+        let phrase = "SwiftUI tokenization reliability benchmark"
+        let repetitions = 12
+        let input = Array(repeating: phrase, count: repetitions).joined(separator: " ")
+
+        let expectedTokensPerPhrase = phrase.split(separator: " ").count
+        let tokens = engine.tokenize(input)
+
+        XCTAssertEqual(tokens.count, expectedTokensPerPhrase * repetitions)
+        XCTAssertEqual(Set(tokens).count, expectedTokensPerPhrase)
+    }
+}

--- a/macos-tokenizer.xcodeproj/project.pbxproj
+++ b/macos-tokenizer.xcodeproj/project.pbxproj
@@ -7,21 +7,79 @@ objectVersion = 56;
 objects = {
 
 /* Begin PBXBuildFile section */
+B65B5A9D036A4BE789795A84 /* TokenizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C830EE3E1E43CDAD5AA945 /* TokenizationTests.swift */; };
+6F1E79D4D3714AC9B65E626D /* ExportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE552B1A7EC243029B538E7E /* ExportTests.swift */; };
 B4F5C1C02B3ED4F500A67135 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F5C1BF2B3ED4F500A67135 /* App.swift */; };
+2FA758887D5B43D4BAA84185 /* FileImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F0A11620D148B18BCFCAA2 /* FileImporter.swift */; };
+26FA4A835E1D48BC9B318148 /* TokenExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7380E75CE018453A9CD891EC /* TokenExportService.swift */; };
+CFD9CB89616A44F4B49624E0 /* ThemeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34023BE631A4445FB75963AF /* ThemeManager.swift */; };
+2AEA284DF42942B0994C88B7 /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B4C7594F7E4083ABC3E937 /* DesignSystem.swift */; };
+DBA28C412741492E8D040DBB /* TokenizerEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2060CB0B49D24E7192DCFBE0 /* TokenizerEngine.swift */; };
+E20E962A1E964F9F8480E8FB /* DropZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FD861277FFE48B5A43417D6 /* DropZone.swift */; };
+2214969DE3B344BB8E600140 /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1239203C21F4857BDCA8CA2 /* SparklineView.swift */; };
+9B5482B607A943DDA6BD14AB /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 997A90E822BD4BE3B08B5DD0 /* Card.swift */; };
+3EABEDA8703D49E79971A2A2 /* StatCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6D09443B664F9BB4254A94 /* StatCard.swift */; };
+26062FB38D204820879B96D9 /* Badge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61421DCE6538403DB011DD6B /* Badge.swift */; };
+4463EE45E32344BCA1A1EA15 /* AppShellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138052E8AFE440BFB0B2A332 /* AppShellView.swift */; };
+A7A1FF5C8920499F894511F0 /* TokenizerMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2D013C8FFC43D2945128AB /* TokenizerMainView.swift */; };
+3BCEA9DC3231446B98732400 /* TokenizerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CC7D8E166C4470BD7F6792 /* TokenizerViewModel.swift */; };
+D8036422E7804923AAC0955D /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB90BD7D50E49968D536BEE /* DashboardViewModel.swift */; };
+736E692AD897481B89442999 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE8DB25B4C9412A87D1EBA0 /* DashboardView.swift */; };
+FBE6498FE6F9436B99328C31 /* AppRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90A3A35E0EE46B0BE829BDA /* AppRoute.swift */; };
+04502E164CD842D590BA495E /* PlaceholderViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB6A35009C74410B4B03E35 /* PlaceholderViews.swift */; };
+CF24E5F479E44F8AB7EEF3DC /* CoreXLSX in Frameworks */ = {isa = PBXBuildFile; productRef = EEF23352D262499E805EC943 /* CoreXLSX */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+6D259992C5D5428795D72EE1 /* PBXContainerItemProxy */ = {
+    isa = PBXContainerItemProxy;
+    containerPortal = B4F5C1B72B3ED4F500A67135 /* Project object */;
+    proxyType = 1;
+    remoteGlobalIDString = B4F5C1BD2B3ED4F500A67135;
+    remoteInfo = "macos-tokenizer";
+};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 B4F5C1BF2B3ED4F500A67135 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 B4F5C1C22B3ED4F500A67135 /* macos-tokenizer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "macos-tokenizer.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+C2D2A5389B71451C91210B1C /* macos-tokenizerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "macos-tokenizerTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+C3C830EE3E1E43CDAD5AA945 /* TokenizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenizationTests.swift; sourceTree = "<group>"; };
+CE552B1A7EC243029B538E7E /* ExportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportTests.swift; sourceTree = "<group>"; };
+C3F0A11620D148B18BCFCAA2 /* FileImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileImporter.swift; sourceTree = "<group>"; };
+7380E75CE018453A9CD891EC /* TokenExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenExportService.swift; sourceTree = "<group>"; };
+34023BE631A4445FB75963AF /* ThemeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeManager.swift; sourceTree = "<group>"; };
+C7B4C7594F7E4083ABC3E937 /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
+2060CB0B49D24E7192DCFBE0 /* TokenizerEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenizerEngine.swift; sourceTree = "<group>"; };
+7FD861277FFE48B5A43417D6 /* DropZone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropZone.swift; sourceTree = "<group>"; };
+B1239203C21F4857BDCA8CA2 /* SparklineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparklineView.swift; sourceTree = "<group>"; };
+997A90E822BD4BE3B08B5DD0 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+5B6D09443B664F9BB4254A94 /* StatCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatCard.swift; sourceTree = "<group>"; };
+61421DCE6538403DB011DD6B /* Badge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Badge.swift; sourceTree = "<group>"; };
+138052E8AFE440BFB0B2A332 /* AppShellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppShellView.swift; sourceTree = "<group>"; };
+CC2D013C8FFC43D2945128AB /* TokenizerMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenizerMainView.swift; sourceTree = "<group>"; };
+64CC7D8E166C4470BD7F6792 /* TokenizerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenizerViewModel.swift; sourceTree = "<group>"; };
+CBB90BD7D50E49968D536BEE /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
+6EE8DB25B4C9412A87D1EBA0 /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
+B90A3A35E0EE46B0BE829BDA /* AppRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRoute.swift; sourceTree = "<group>"; };
+0AB6A35009C74410B4B03E35 /* PlaceholderViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderViews.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 B4F5C1BC2B3ED4F500A67135 /* Frameworks */ = {
-isa = PBXFrameworksBuildPhase;
-buildActionMask = 2147483647;
-files = (
-);
-runOnlyForDeploymentPostprocessing = 0;
+    isa = PBXFrameworksBuildPhase;
+    buildActionMask = 2147483647;
+    files = (
+        CF24E5F479E44F8AB7EEF3DC /* CoreXLSX in Frameworks */,
+    );
+    runOnlyForDeploymentPostprocessing = 0;
+};
+E80FB2F3E0214A15A9A20DB9 /* Frameworks */ = {
+    isa = PBXFrameworksBuildPhase;
+    buildActionMask = 2147483647;
+    files = (
+    );
+    runOnlyForDeploymentPostprocessing = 0;
 };
 /* End PBXFrameworksBuildPhase section */
 
@@ -49,6 +107,10 @@ B4F5C1BE2B3ED4F500A67135 /* App */ = {
 B4F5C1D22B3ED65A00A67135 /* Core */ = {
     isa = PBXGroup;
     children = (
+        780179E4928D4B5897785491 /* FileImporter */,
+        C1C538560398447F9A565F82 /* Export */,
+        92AFCC46E3634B0E860D32AD /* Infra */,
+        F973C904657B4451AD509982 /* Tokenization */,
     );
     path = Core;
     sourceTree = "<group>";
@@ -56,6 +118,10 @@ B4F5C1D22B3ED65A00A67135 /* Core */ = {
 B4F5C1D32B3ED65A00A67135 /* Features */ = {
     isa = PBXGroup;
     children = (
+        5DC748DC03EF4A2CBF636E67 /* Components */,
+        D90358AE4B2C47E2A32EDCDE /* TokenizerUI */,
+        7D9831FFE2904D21AE3D3577 /* Dashboard */,
+        2E63200CA82C4F2AB1E8B800 /* Shell */,
     );
     path = Features;
     sourceTree = "<group>";
@@ -70,36 +136,141 @@ B4F5C1D42B3ED65A00A67135 /* Resources */ = {
 B4F5C1D52B3ED65A00A67135 /* Tests */ = {
     isa = PBXGroup;
     children = (
+        C3C830EE3E1E43CDAD5AA945 /* TokenizationTests.swift */,
+        CE552B1A7EC243029B538E7E /* ExportTests.swift */,
     );
     path = Tests;
     sourceTree = "<group>";
 };
 B4F5C1C12B3ED4F500A67135 /* Products */ = {
-isa = PBXGroup;
-children = (
-B4F5C1C22B3ED4F500A67135 /* macos-tokenizer.app */,
-);
-name = Products;
-sourceTree = "<group>";
+    isa = PBXGroup;
+    children = (
+        B4F5C1C22B3ED4F500A67135 /* macos-tokenizer.app */,
+        C2D2A5389B71451C91210B1C /* macos-tokenizerTests.xctest */,
+    );
+    name = Products;
+    sourceTree = "<group>";
+};
+780179E4928D4B5897785491 /* FileImporter */ = {
+    isa = PBXGroup;
+    children = (
+        C3F0A11620D148B18BCFCAA2 /* FileImporter.swift */,
+    );
+    path = FileImporter;
+    sourceTree = "<group>";
+};
+C1C538560398447F9A565F82 /* Export */ = {
+    isa = PBXGroup;
+    children = (
+        7380E75CE018453A9CD891EC /* TokenExportService.swift */,
+    );
+    path = Export;
+    sourceTree = "<group>";
+};
+92AFCC46E3634B0E860D32AD /* Infra */ = {
+    isa = PBXGroup;
+    children = (
+        34023BE631A4445FB75963AF /* ThemeManager.swift */,
+        C7B4C7594F7E4083ABC3E937 /* DesignSystem.swift */,
+    );
+    path = Infra;
+    sourceTree = "<group>";
+};
+F973C904657B4451AD509982 /* Tokenization */ = {
+    isa = PBXGroup;
+    children = (
+        2060CB0B49D24E7192DCFBE0 /* TokenizerEngine.swift */,
+    );
+    path = Tokenization;
+    sourceTree = "<group>";
+};
+5DC748DC03EF4A2CBF636E67 /* Components */ = {
+    isa = PBXGroup;
+    children = (
+        61421DCE6538403DB011DD6B /* Badge.swift */,
+        997A90E822BD4BE3B08B5DD0 /* Card.swift */,
+        7FD861277FFE48B5A43417D6 /* DropZone.swift */,
+        B1239203C21F4857BDCA8CA2 /* SparklineView.swift */,
+        5B6D09443B664F9BB4254A94 /* StatCard.swift */,
+        9B4BC57384E343848C567513 /* AppShell */,
+    );
+    path = Components;
+    sourceTree = "<group>";
+};
+9B4BC57384E343848C567513 /* AppShell */ = {
+    isa = PBXGroup;
+    children = (
+        138052E8AFE440BFB0B2A332 /* AppShellView.swift */,
+    );
+    path = AppShell;
+    sourceTree = "<group>";
+};
+D90358AE4B2C47E2A32EDCDE /* TokenizerUI */ = {
+    isa = PBXGroup;
+    children = (
+        CC2D013C8FFC43D2945128AB /* TokenizerMainView.swift */,
+        64CC7D8E166C4470BD7F6792 /* TokenizerViewModel.swift */,
+    );
+    path = TokenizerUI;
+    sourceTree = "<group>";
+};
+7D9831FFE2904D21AE3D3577 /* Dashboard */ = {
+    isa = PBXGroup;
+    children = (
+        CBB90BD7D50E49968D536BEE /* DashboardViewModel.swift */,
+        6EE8DB25B4C9412A87D1EBA0 /* DashboardView.swift */,
+    );
+    path = Dashboard;
+    sourceTree = "<group>";
+};
+2E63200CA82C4F2AB1E8B800 /* Shell */ = {
+    isa = PBXGroup;
+    children = (
+        B90A3A35E0EE46B0BE829BDA /* AppRoute.swift */,
+        0AB6A35009C74410B4B03E35 /* PlaceholderViews.swift */,
+    );
+    path = Shell;
+    sourceTree = "<group>";
 };
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
 B4F5C1BD2B3ED4F500A67135 /* macos-tokenizer */ = {
-isa = PBXNativeTarget;
-buildConfigurationList = B4F5C1CB2B3ED4F600A67135 /* Build configuration list for PBXNativeTarget "macos-tokenizer" */;
-buildPhases = (
-B4F5C1BB2B3ED4F500A67135 /* Sources */,
-B4F5C1BC2B3ED4F500A67135 /* Frameworks */,
-);
-buildRules = (
-);
-dependencies = (
-);
-name = "macos-tokenizer";
-productName = "macos-tokenizer";
-productReference = B4F5C1C22B3ED4F500A67135 /* macos-tokenizer.app */;
-productType = "com.apple.product-type.application";
+    isa = PBXNativeTarget;
+    buildConfigurationList = B4F5C1CB2B3ED4F600A67135 /* Build configuration list for PBXNativeTarget "macos-tokenizer" */;
+    buildPhases = (
+        B4F5C1BB2B3ED4F500A67135 /* Sources */,
+        B4F5C1BC2B3ED4F500A67135 /* Frameworks */,
+    );
+    buildRules = (
+    );
+    dependencies = (
+    );
+    packageProductDependencies = (
+        EEF23352D262499E805EC943 /* CoreXLSX */,
+    );
+    name = "macos-tokenizer";
+    productName = "macos-tokenizer";
+    productReference = B4F5C1C22B3ED4F500A67135 /* macos-tokenizer.app */;
+    productType = "com.apple.product-type.application";
+};
+82B545D366C94C488F187997 /* macos-tokenizerTests */ = {
+    isa = PBXNativeTarget;
+    buildConfigurationList = B2348D8445FF491F9DB07752 /* Build configuration list for PBXNativeTarget "macos-tokenizerTests" */;
+    buildPhases = (
+        078F8B750F78441AA3A84D59 /* Sources */,
+        E80FB2F3E0214A15A9A20DB9 /* Frameworks */,
+        3147CEC330E244FFA0276023 /* Resources */,
+    );
+    buildRules = (
+    );
+    dependencies = (
+        55884E73FDEB40F599D57A09 /* PBXTargetDependency */,
+    );
+    name = "macos-tokenizerTests";
+    productName = "macos-tokenizerTests";
+    productReference = C2D2A5389B71451C91210B1C /* macos-tokenizerTests.xctest */;
+    productType = "com.apple.product-type.bundle.unit-test";
 };
 /* End PBXNativeTarget section */
 
@@ -110,11 +281,15 @@ attributes = {
 BuildIndependentTargetsInParallel = 1;
 LastSwiftUpdateCheck = 1500;
 LastUpgradeCheck = 1500;
-TargetAttributes = {
-B4F5C1BD2B3ED4F500A67135 = {
-CreatedOnToolsVersion = 15.0;
-};
-};
+        TargetAttributes = {
+            B4F5C1BD2B3ED4F500A67135 = {
+                CreatedOnToolsVersion = 15.0;
+            };
+            82B545D366C94C488F187997 = {
+                CreatedOnToolsVersion = 15.0;
+                TestTargetID = B4F5C1BD2B3ED4F500A67135;
+            };
+        };
 };
 buildConfigurationList = B4F5C1BA2B3ED4F500A67135 /* Build configuration list for PBXProject "macos-tokenizer" */;
 compatibilityVersion = "Xcode 14.0";
@@ -123,26 +298,93 @@ hasScannedForEncodings = 0;
 knownRegions = (
 en,
 );
-mainGroup = B4F5C1B62B3ED4F500A67135;
-productRefGroup = B4F5C1C12B3ED4F500A67135 /* Products */;
-projectDirPath = "";
-projectRoot = "";
-targets = (
-B4F5C1BD2B3ED4F500A67135 /* macos-tokenizer */,
-);
+    mainGroup = B4F5C1B62B3ED4F500A67135;
+    productRefGroup = B4F5C1C12B3ED4F500A67135 /* Products */;
+    projectDirPath = "";
+    projectRoot = "";
+    packageReferences = (
+        5E11A11642B643C3BBBBFA09 /* CoreXLSX */,
+    );
+    targets = (
+        B4F5C1BD2B3ED4F500A67135 /* macos-tokenizer */,
+        82B545D366C94C488F187997 /* macos-tokenizerTests */,
+    );
 };
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+3147CEC330E244FFA0276023 /* Resources */ = {
+    isa = PBXResourcesBuildPhase;
+    buildActionMask = 2147483647;
+    files = (
+    );
+    runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 B4F5C1BB2B3ED4F500A67135 /* Sources */ = {
-isa = PBXSourcesBuildPhase;
-buildActionMask = 2147483647;
-files = (
-B4F5C1C02B3ED4F500A67135 /* App.swift in Sources */,
-);
-runOnlyForDeploymentPostprocessing = 0;
+    isa = PBXSourcesBuildPhase;
+    buildActionMask = 2147483647;
+    files = (
+        B4F5C1C02B3ED4F500A67135 /* App.swift in Sources */,
+        2FA758887D5B43D4BAA84185 /* FileImporter.swift in Sources */,
+        26FA4A835E1D48BC9B318148 /* TokenExportService.swift in Sources */,
+        CFD9CB89616A44F4B49624E0 /* ThemeManager.swift in Sources */,
+        2AEA284DF42942B0994C88B7 /* DesignSystem.swift in Sources */,
+        DBA28C412741492E8D040DBB /* TokenizerEngine.swift in Sources */,
+        E20E962A1E964F9F8480E8FB /* DropZone.swift in Sources */,
+        2214969DE3B344BB8E600140 /* SparklineView.swift in Sources */,
+        9B5482B607A943DDA6BD14AB /* Card.swift in Sources */,
+        3EABEDA8703D49E79971A2A2 /* StatCard.swift in Sources */,
+        26062FB38D204820879B96D9 /* Badge.swift in Sources */,
+        4463EE45E32344BCA1A1EA15 /* AppShellView.swift in Sources */,
+        A7A1FF5C8920499F894511F0 /* TokenizerMainView.swift in Sources */,
+        3BCEA9DC3231446B98732400 /* TokenizerViewModel.swift in Sources */,
+        D8036422E7804923AAC0955D /* DashboardViewModel.swift in Sources */,
+        736E692AD897481B89442999 /* DashboardView.swift in Sources */,
+        FBE6498FE6F9436B99328C31 /* AppRoute.swift in Sources */,
+        04502E164CD842D590BA495E /* PlaceholderViews.swift in Sources */,
+    );
+    runOnlyForDeploymentPostprocessing = 0;
+};
+078F8B750F78441AA3A84D59 /* Sources */ = {
+    isa = PBXSourcesBuildPhase;
+    buildActionMask = 2147483647;
+    files = (
+        B65B5A9D036A4BE789795A84 /* TokenizationTests.swift in Sources */,
+        6F1E79D4D3714AC9B65E626D /* ExportTests.swift in Sources */,
+    );
+    runOnlyForDeploymentPostprocessing = 0;
 };
 /* End PBXSourcesBuildPhase section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+5E11A11642B643C3BBBBFA09 /* CoreXLSX */ = {
+    isa = XCRemoteSwiftPackageReference;
+    repositoryURL = "https://github.com/CoreOffice/CoreXLSX.git";
+    requirement = {
+        kind = upToNextMajorVersion;
+        minimumVersion = 0.17.1;
+    };
+};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+EEF23352D262499E805EC943 /* CoreXLSX */ = {
+    isa = XCSwiftPackageProductDependency;
+    package = 5E11A11642B643C3BBBBFA09 /* CoreXLSX */;
+    productName = CoreXLSX;
+};
+/* End XCSwiftPackageProductDependency section */
+
+/* Begin PBXTargetDependency section */
+55884E73FDEB40F599D57A09 /* PBXTargetDependency */ = {
+    isa = PBXTargetDependency;
+    target = B4F5C1BD2B3ED4F500A67135 /* macos-tokenizer */;
+    targetProxy = 6D259992C5D5428795D72EE1 /* PBXContainerItemProxy */;
+};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 B4F5C1C82B3ED4F600A67135 /* Debug */ = {
@@ -247,10 +489,10 @@ SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 name = Debug;
 };
 B4F5C1CD2B3ED4F600A67135 /* Release */ = {
-isa = XCBuildConfiguration;
-buildSettings = {
-ALWAYS_SEARCH_USER_PATHS = NO;
-CLANG_ANALYZER_NONNULL = YES;
+    isa = XCBuildConfiguration;
+    buildSettings = {
+        ALWAYS_SEARCH_USER_PATHS = NO;
+        CLANG_ANALYZER_NONNULL = YES;
 CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 CLANG_ENABLE_MODULES = YES;
@@ -293,8 +535,50 @@ MTL_ENABLE_DEBUG_INFO = NO;
 SDKROOT = macosx;
 SWIFT_COMPILATION_MODE = wholemodule;
 SWIFT_OPTIMIZATION_LEVEL = "-O";
+    };
+    name = Release;
 };
-name = Release;
+B925708ED47A40B28F6DE3A4 /* Debug */ = {
+    isa = XCBuildConfiguration;
+    buildSettings = {
+        BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/macos-tokenizer.app/Contents/MacOS/macos-tokenizer";
+        CODE_SIGN_STYLE = Automatic;
+        COMBINE_HIDPI_IMAGES = YES;
+        CURRENT_PROJECT_VERSION = 1;
+        GENERATE_INFOPLIST_FILE = YES;
+        LD_RUNPATH_SEARCH_PATHS = (
+            "$(inherited)",
+            "@executable_path/../Frameworks",
+            "@loader_path/../Frameworks",
+        );
+        MACOSX_DEPLOYMENT_TARGET = 13.0;
+        PRODUCT_BUNDLE_IDENTIFIER = com.example.macosTokenizerTests;
+        PRODUCT_NAME = "$(TARGET_NAME)";
+        SWIFT_VERSION = 5.0;
+        TEST_HOST = "$(BUNDLE_LOADER)";
+    };
+    name = Debug;
+};
+B7F0188A227F4AEF81D2AF18 /* Release */ = {
+    isa = XCBuildConfiguration;
+    buildSettings = {
+        BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/macos-tokenizer.app/Contents/MacOS/macos-tokenizer";
+        CODE_SIGN_STYLE = Automatic;
+        COMBINE_HIDPI_IMAGES = YES;
+        CURRENT_PROJECT_VERSION = 1;
+        GENERATE_INFOPLIST_FILE = YES;
+        LD_RUNPATH_SEARCH_PATHS = (
+            "$(inherited)",
+            "@executable_path/../Frameworks",
+            "@loader_path/../Frameworks",
+        );
+        MACOSX_DEPLOYMENT_TARGET = 13.0;
+        PRODUCT_BUNDLE_IDENTIFIER = com.example.macosTokenizerTests;
+        PRODUCT_NAME = "$(TARGET_NAME)";
+        SWIFT_VERSION = 5.0;
+        TEST_HOST = "$(BUNDLE_LOADER)";
+    };
+    name = Release;
 };
 /* End XCBuildConfiguration section */
 
@@ -309,13 +593,22 @@ defaultConfigurationIsVisible = 0;
 defaultConfigurationName = Release;
 };
 B4F5C1CB2B3ED4F600A67135 /* Build configuration list for PBXNativeTarget "macos-tokenizer" */ = {
-isa = XCConfigurationList;
-buildConfigurations = (
-B4F5C1C82B3ED4F600A67135 /* Debug */,
-B4F5C1C92B3ED4F600A67135 /* Release */,
-);
-defaultConfigurationIsVisible = 0;
-defaultConfigurationName = Release;
+    isa = XCConfigurationList;
+    buildConfigurations = (
+        B4F5C1C82B3ED4F600A67135 /* Debug */,
+        B4F5C1C92B3ED4F600A67135 /* Release */,
+    );
+    defaultConfigurationIsVisible = 0;
+    defaultConfigurationName = Release;
+};
+B2348D8445FF491F9DB07752 /* Build configuration list for PBXNativeTarget "macos-tokenizerTests" */ = {
+    isa = XCConfigurationList;
+    buildConfigurations = (
+        B925708ED47A40B28F6DE3A4 /* Debug */,
+        B7F0188A227F4AEF81D2AF18 /* Release */,
+    );
+    defaultConfigurationIsVisible = 0;
+    defaultConfigurationName = Release;
 };
 /* End XCConfigurationList section */
 };


### PR DESCRIPTION
## Summary
- include the missing App, Core, and Features Swift files in the Xcode project groups and Sources build phase
- add the CoreXLSX Swift package dependency and link it to the macos-tokenizer target
- create a macOS unit test target with minimal tokenizer and export coverage

## Testing
- not run (project and test file updates only)

------
https://chatgpt.com/codex/tasks/task_e_68e0f49cb2688323b65935478b487747